### PR TITLE
Point to right url

### DIFF
--- a/core/Government/Ghent-Belgium.yml
+++ b/core/Government/Ghent-Belgium.yml
@@ -1,6 +1,6 @@
 ---
 title: Ghent, Belgium
-homepage: https://data.stad.gent/datasets
+homepage: https://data.stad.gent/data
 category: Government
 description:
 version:


### PR DESCRIPTION
pointed to https://data.stad.gent/datasets instead of https://data.stad.gent/data

---
title: Data set name
homepage: www.example.com
category: Government
description: Long description of dataset
version: 1.0
keywords: keyword1, keyword2
image: www.example.com/image.jpg
temporal:
spatial:
access_level: public
copyrights:
accrual_periodicity: monthly
specification:
data_quality: false
data_dictionary: www.example.com/dictionary.html
language: en
license: Apache License
publisher:
  - name: Publisher name
    web: www.example.com/publisher
organization:
  - name: Org. name
    web: www.example.com/organization
issued_time: 2017.01
sources:
  - name: source name
    access_url: www.example.com
references:
  - title: related story
    reference: www.example.com
