### PR TITLE
Add Luxembourgish Open Data portal

### DIFF
--- a/core/Government/Luxembourg.yml
+++ b/core/Government/Luxembourg.yml
@@ -1,0 +1,23 @@
+---
+title: Luxembourg
+homepage: https://data.public.lu/en/
+category: Government
+description: Luxembourgish Open Data Portal
+version: 1.0
+keywords: luxembourg
+image: https://data.public.lu/_themes/gouvlu/img/logo-bloc-borderless.svg?_=1.0.1
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality:
+data_dictionary:
+language: fr, en
+license: CC0 1.0 https://creativecommons.org/publicdomain/zero/1.0/deed.fr
+publisher:
+organization:
+issued_time:
+sources:
+references:


### PR DESCRIPTION
---
title: Data set name
homepage: www.example.com
category: Government
description: Long description of dataset
version: 1.0
keywords: keyword1, keyword2
image: www.example.com/image.jpg
temporal:
spatial:
access_level: public
copyrights:
accrual_periodicity: monthly
specification:
data_quality: false
data_dictionary: www.example.com/dictionary.html
language: en
license: Apache License
publisher:
  - name: Publisher name
    web: www.example.com/publisher
organization:
  - name: Org. name
    web: www.example.com/organization
issued_time: 2017.01
sources:
  - name: source name
    access_url: www.example.com
references:
  - title: related story
    reference: www.example.com
