### PR TITLE
Added Bit-Bots ImageTagger

### DIFF
--- a/core/ImageProcessing/BitBots-ImageTagger.yml
+++ b/core/ImageProcessing/BitBots-ImageTagger.yml
@@ -1,0 +1,24 @@
+---
+title: Bit-Bots ImageTagger
+homepage: imagetagger.bit-bots.de
+category: ImageProcessing
+description: Images of and from humanoid soccer robots participating in RoboCup Soccer
+version: 1.0
+keywords: RoboCup, Humanoid Robot Soccer, Ball
+image: 
+temporal:
+spatial:
+access_level: public after registration
+copyrights:
+accrual_periodicity: 
+specification:
+data_quality: false
+data_dictionary: 
+language: en
+license: MIT
+publisher:
+  - name: Hamburg Bit-Bots
+    web: bit-bots.de
+references:
+  - title: ImageTagger: An Open Source Online Platform for Collaborative Image Labeling
+    reference: https://github.com/bit-bots/imagetagger

--- a/core/ImageProcessing/BitBots-ImageTagger.yml
+++ b/core/ImageProcessing/BitBots-ImageTagger.yml
@@ -20,5 +20,5 @@ publisher:
   - name: Hamburg Bit-Bots
     web: bit-bots.de
 references:
-  - title: ImageTagger: An Open Source Online Platform for Collaborative Image Labeling
-    reference: https://github.com/bit-bots/imagetagger
+  - title: ImageTagger - An Open Source Online Platform for Collaborative Image Labeling
+    reference: www.github.com/bit-bots/imagetagger


### PR DESCRIPTION
I added the [Bit-Bots Imagetagger](https://imagetagger.bit-bots.de), with currently nearly 200.000 Images out of the RoboCup Soccer context publicly available.