### PR TITLE
update nerrs-swmp to http instead of www

### DIFF
--- a/core/EarthScience/NERRS-SWMP.yml
+++ b/core/EarthScience/NERRS-SWMP.yml
@@ -1,6 +1,6 @@
 ---
 title: National Estuarine Research Reserves System-Wide Monitoring Program
-homepage: www.nerrsdata.org
+homepage: http://nerrsdata.org
 category: EarthScience
 description: long-term estuarine monitoring data
 version: 
@@ -18,7 +18,7 @@ language: en
 license: 
 publisher:
   - name: NOAA NERRS Centralized Data Management Office
-    web: www.nerrsdata.org
+    web: http://nerrsdata.org
 organization:
   - name: NOAA Natioanal Estuarine Research Reserve System
     web: https://coast.noaa.gov/nerrs/


### PR DESCRIPTION
With 'www.nerrsdata.org' in the file, the link in Awesome Public Datasets went to 'https://github.com/awesomedata/awesome-public-datasets/blob/master/www.nerrsdata.org'

So I updated it to 'http://nerrsdata.org'. I *think* this should work...