### PR TITLE
Updated to working link

### DIFF
--- a/core/SocialSciences/Humanitarian-Data-Exchange.yml
+++ b/core/SocialSciences/Humanitarian-Data-Exchange.yml
@@ -1,6 +1,6 @@
 ---
 title: Humanitarian Data Exchange
-homepage: https://data.hdx.rwlabs.org/
+homepage: https://data.humdata.org/
 category: SocialSciences
 description:
 version:


### PR DESCRIPTION
---
title: Humanitarian Data Exchange
homepage: https://data.humdata.org/
category: SocialSciences
description: The Humanitarian Data Exchange (HDX) is an open platform for sharing data, launched in July 2014. The goal of HDX is to make humanitarian data easy to find and use for analysis. Our growing collection of datasets has been accessed by users in over 200 countries and territories. Watch this video to learn more.

A team within the United Nations Office for the Coordination of Humanitarian Affairs (OCHA) manages HDX. OCHA is part of the United Nations Secretariat, responsible for bringing together humanitarian actors to ensure a coherent response to emergencies. The HDX team includes OCHA staff and a number of consultants. We are based in North America, Europe and Africa.
version: 
keywords: 
image: 
temporal:
spatial:
access_level: 
copyrights:
accrual_periodicity: 
specification:
data_quality: false
data_dictionary: 
language: 
license: 
publisher:
  - name: 
    web: 
organization:
  - name: 
    web: 
issued_time: 
sources:
  - name: 
    access_url: 
references:
  - title: 
    reference:
