### PR TITLE
added NeuroMorpho

### DIFF
--- a/core/Neuroscience/NeuroMorpho.yml
+++ b/core/Neuroscience/NeuroMorpho.yml
@@ -1,0 +1,23 @@
+---
+title: NeuroMorpho
+homepage: http://neuromorpho.org/
+category: Neuroscience
+description: NeuroMorpho.Org is a centrally curated inventory of digitally reconstructed neurons associated with peer-reviewed publications. It contains contributions from over 400 laboratories worldwide and is continuously updated as new morphological reconstructions are collected, published, and shared. To date, NeuroMorpho.Org is the largest collection of publicly accessible 3D neuronal reconstructions and associated metadata.
+ersion: 7.5
+keywords: Neuron, morphology
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license:
+publisher:
+organization:
+issued_time: 2018.08
+sources:
+references:


### PR DESCRIPTION
Added NeuroMopho.org dataset: an inventory of digitally reconstructed neurons associated with peer-reviewed publications.