### PR TITLE
Update NYC Open Data Homepage URL

### DIFF
--- a/core/Government/NYC-Open-Data.yml
+++ b/core/Government/NYC-Open-Data.yml
@@ -1,6 +1,6 @@
 ---
 title: NYC Open Data
-homepage: https://nycplatform.socrata.com/
+homepage: https://opendata.cityofnewyork.us/
 category: Government
 description:
 version:


### PR DESCRIPTION
This change updates the URL to the NYC Open Data portal.