### PR TITLE
Added Soil Moisture Dataset

### DIFF
--- a/core/Agriculture/Hyperspectral-Benchmark-Dataset-On-Soil-Moisture.yml
+++ b/core/Agriculture/Hyperspectral-Benchmark-Dataset-On-Soil-Moisture.yml
@@ -1,0 +1,28 @@
+---
+title: Hyperspectral benchmark dataset on soil moisture
+homepage: https://doi.org/10.5281/zenodo.1227837
+category: Agriculture
+description: EuroSAT: Hyperspectral and soil-moisture data from a field campaign based on a soil sample. Karlsruhe (Germany), 2017.
+version: 1.0
+keywords: hyperspectral, soil moisture, field campaign
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity: 
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license: GNU GPLv2
+publisher:
+  - name: Felix M. Riese, Sina Keller
+    web: http://www.ipf.kit.edu/english/staff_riese_felix.php
+organization:
+  - name: Karlsruhe Institute of Technology (KIT) 
+    web: http://www.ipf.kit.edu/english/index.php
+issued_time: 2018.04
+references:
+  - title: Introducing a Framework of Self-Organizing Maps for Regression of Soil Moisture with Hyperspectral Data
+    reference: https://www.igarss2018.org

--- a/core/GIS/GRSS-DASE-Website.yml
+++ b/core/GIS/GRSS-DASE-Website.yml
@@ -1,0 +1,25 @@
+---
+title: IEEE Geoscience and Remote Sensing Society DASE Website
+homepage: http://dase.ticinumaerospace.com
+category: GIS
+description: The Standardized Remote Sensing Data Website of the IEEE Geoscience and Remote Sensing Society (GRSS) provides a set of community data sets and algorithm evaluation standards for use by the Earth observation community to support research, development, and testing of algorithms for remote sensing data products.
+version:
+keywords: geoscience, remote sensing
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity: 
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license: 
+publisher:
+  - name: IEEE Geoscience and Remote Sensing Society (GRSS)
+    web: http://www.grss-ieee.org
+organization:
+  - name: IEEE
+    web: https://www.ieee.org
+


### PR DESCRIPTION
---
title: Hyperspectral benchmark dataset on soil moisture
homepage: https://doi.org/10.5281/zenodo.1227837
category: Agriculture
description: EuroSAT: Hyperspectral and soil-moisture data from a field campaign based on a soil sample. Karlsruhe (Germany), 2017.
version: 1.0
keywords: hyperspectral, soil moisture, field campaign
image:
temporal:
spatial:
access_level: public
copyrights:
accrual_periodicity: 
specification:
data_quality: false
data_dictionary:
language: en
license: GNU GPLv2
publisher:
  - name: Felix M. Riese, Sina Keller
    web: http://www.ipf.kit.edu/english/staff_riese_felix.php
organization:
  - name: Karlsruhe Institute of Technology (KIT) 
    web: http://www.ipf.kit.edu/english/index.php
issued_time: 2018.04
references:
  - title: Introducing a Framework of Self-Organizing Maps for Regression of Soil Moisture with Hyperspectral Data
    reference: https://www.igarss2018.org