### PR TITLE
Updated the link of data from freecodecamp

### DIFF
--- a/core/Education/Student-Data-from-Free-Code-Camp.yml
+++ b/core/Education/Student-Data-from-Free-Code-Camp.yml
@@ -1,6 +1,6 @@
 ---
 title: Student Data from Free Code Camp
-homepage: http://academictorrents.com/details/030b10dad0846b5aecc3905692890fb02404adbf
+homepage: https://github.com/freeCodeCamp/open-data
 category: Education
 description:
 version:


### PR DESCRIPTION
All the data of freecodecamp is available on github

---
title: Student Data from Free Code Camp
homepage: https://github.com/freeCodeCamp/open-data
category: Education
description:
version:
keywords:
image:
temporal:
spatial:
access_level:
copyrights:
accrual_periodicity:
specification:
data_quality: false
data_dictionary:
language:
license:
publisher:
organization:
issued_time:
sources: []