### PR TITLE
Add 2 new datasets to Software section:

### DIFF
--- a/core/Software/source{d}-Public-Git-Archive.yml
+++ b/core/Software/source{d}-Public-Git-Archive.yml
@@ -1,0 +1,22 @@
+---
+title: Public Git Archive
+homepage: https://github.com/src-d/datasets/tree/master/PublicGitArchive
+category: Software
+description: a Big Code dataset for all – dataset of 182,014 top-bookmarked Git repositories from GitHub
+version:
+keywords: source code, git, GitHub, software repositories, development history, open dataset
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language:
+license:
+publisher:
+organization:
+issued_time:
+sources: []

--- a/core/Software/source{d}-source-code-identifiers.yml
+++ b/core/Software/source{d}-source-code-identifiers.yml
@@ -1,0 +1,22 @@
+---
+title: Source Code Identifiers
+homepage: https://github.com/src-d/datasets/tree/master/Identifiers
+category: Software
+description: 41.7 million distinct splittable identifiers collected from 182,014 open source projects in Public Git Archive
+version:
+keywords: source code, git, GitHub, software repositories, development history, open dataset
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language:
+license:
+publisher:
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
* Public Git Archive
* Source Code Identifiers

Signed-off-by: egor <egor@sourced.tech>

---
title: Public Git Archive
homepage: https://github.com/src-d/datasets/tree/master/PublicGitArchive
category: Software
description: a Big Code dataset for all – dataset of 182,014 top-bookmarked Git repositories from GitHub
version:
keywords: source code, git, GitHub, software repositories, development history, open dataset
image:
temporal:
spatial:
access_level:
copyrights:
accrual_periodicity:
specification:
data_quality: false
data_dictionary:
language:
license:
publisher:
organization:
issued_time:
sources: []

---
title: Source Code Identifiers
homepage: https://github.com/src-d/datasets/tree/master/Identifiers
category: Software
description: 41.7 million distinct splittable identifiers collected from 182,014 open source projects in Public Git Archive
version:
keywords: source code, git, GitHub, software repositories, development history, open dataset
image:
temporal:
spatial:
access_level:
copyrights:
accrual_periodicity:
specification:
data_quality: false
data_dictionary:
language:
license:
publisher:
organization:
issued_time:
sources: []
