### PR TITLE
Update Bay-Area-Bike-Share-Data.yml

### DIFF
--- a/core/Transportation/Bay-Area-Bike-Share-Data.yml
+++ b/core/Transportation/Bay-Area-Bike-Share-Data.yml
@@ -1,6 +1,6 @@
 ---
-title: Bay Area Bike Share Data
-homepage: http://www.bayareabikeshare.com/open-data
+title: Ford GoBike Data (formerly Bay Area Bike Share Data)
+homepage: https://www.fordgobike.com/system-data
 category: Transportation
 description:
 version:
@@ -14,8 +14,8 @@ accrual_periodicity:
 specification:
 data_quality: false
 data_dictionary:
-language:
-license:
+language: en
+license: https://assets.fordgobike.com/data-license-agreement.html
 publisher:
 organization:
 issued_time:


### PR DESCRIPTION
correcting URL (and name of datasource)

---
---
title: Ford GoBike Data (formerly Bay Area Bike Share Data)
homepage: https://www.fordgobike.com/system-data
category: Transportation
description:
version:
keywords:
image:
temporal:
spatial:
access_level:
copyrights:
accrual_periodicity:
specification:
data_quality: false
data_dictionary:
language: en
license: https://assets.fordgobike.com/data-license-agreement.html
publisher:
organization:
issued_time:
sources: []
