### PR TITLE
Update Toronto-Bike-Share-Stations-XML-file.yml

### DIFF
--- a/core/Transportation/Toronto-Bike-Share-Stations-XML-file.yml
+++ b/core/Transportation/Toronto-Bike-Share-Stations-XML-file.yml
@@ -1,6 +1,6 @@
 ---
-title: Toronto Bike Share Stations (XML file)
-homepage: http://www.bikesharetoronto.com/data/stations/bikeStations.xml
+title: Toronto Bike Share Stations (JSON and GBFS files)
+homepage: https://www.toronto.ca/city-government/data-research-maps/open-data/open-data-catalogue/#84045f23-7465-0892-8889-7b6f91049b29
 category: Transportation
 description:
 version:
@@ -14,7 +14,7 @@ accrual_periodicity:
 specification:
 data_quality: false
 data_dictionary:
-language:
+language: en
 license:
 publisher:
 organization:


### PR DESCRIPTION
Correcting Link

---
---
title: Toronto Bike Share Stations (JSON and GBFS files)
homepage: https://www.toronto.ca/city-government/data-research-maps/open-data/open-data-catalogue/#84045f23-7465-0892-8889-7b6f91049b29
category: Transportation
description:
version:
keywords:
image:
temporal:
spatial:
access_level:
copyrights:
accrual_periodicity:
specification:
data_quality: false
data_dictionary:
language: en
license:
publisher:
organization:
issued_time:
sources: []
