### PR TITLE
Create Spanish-train-system-by-Renfe.yml

### DIFF
--- a/core/Transportation/Spanish-train-system-by-Renfe.yml
+++ b/core/Transportation/Spanish-train-system-by-Renfe.yml
@@ -1,0 +1,22 @@
+---
+title: Renfe (Spanish National Railway Network) dataset
+homepage: data.renfe.com
+category: Transportation
+description:
+version:
+keywords:
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language: es
+license: http://data.renfe.com/legal
+publisher:
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
---
title: Renfe (Spanish National Railway Network) dataset
homepage: data.renfe.com
category: Transportation
description:
version:
keywords:
image:
temporal:
spatial:
access_level: public
copyrights:
accrual_periodicity:
specification:
data_quality: false
data_dictionary:
language: es
license: http://data.renfe.com/legal
publisher:
organization:
issued_time:
sources: []
