### PR TITLE
Add emacs temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ deploy/index.rst
 .idea
 deploy/deploy_key
 deploy/deploy_key.pub
+*~


### PR DESCRIPTION
The tilde is a special character, so you have to escape it with a backslash to refer to it from the command line. ~ is often used to indicate backup or temporary files.May 22, 2012

https://superuser.com/questions/427197/linux-directory-full-of-files-with-tilde-signe-g-example-txt-what-does-it