### PR TITLE
Update url

### DIFF
--- a/core/SocialNetworks/GitHub-Collaboration-Archive.yml
+++ b/core/SocialNetworks/GitHub-Collaboration-Archive.yml
@@ -1,6 +1,6 @@
 ---
 title: GitHub Collaboration Archive
-homepage: https://www.githubarchive.org/
+homepage: https://www.gharchive.org/
 category: SocialNetworks
 description:
 version:


### PR DESCRIPTION
githubarchive.org just redirects to gharchive.org. Updated the url so that it points to the current domain instead of the old one, therefore removing redirects and making it easier to phase out the old domain eventually.