### PR TITLE
Add dataset of commit messages:

### DIFF
--- a/core/Software/source{d}-commit-messages.yml
+++ b/core/Software/source{d}-commit-messages.yml
@@ -1,0 +1,22 @@
+---
+title: Commit messages
+homepage: https://github.com/src-d/datasets/blob/master/CommitMessages
+category: Software
+description: 1.3 billion GitHub commit messages till March 2019
+version:
+keywords: source code, git, GitHub, software repositories, development history, open dataset
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language:
+license: Apache 2.0
+publisher:
+organization: source{d}
+issued_time:
+sources: []


### PR DESCRIPTION
* Commit messages
* Size: 46GB
* Description: 1.3 billion GitHub commit messages till March 2019.

Signed-off-by: egor <egor@sourced.tech>