### PR TITLE
Update titanic survival data

### DIFF
--- a/core/SocialSciences/Titanic-Survival-Data-Set.yml
+++ b/core/SocialSciences/Titanic-Survival-Data-Set.yml
@@ -1,6 +1,6 @@
 ---
 title: Titanic Survival Data Set
-homepage: https://github.com/awesomedata/awesome-public-datasets/tree/master/Datasets
+homepage: https://www.kaggle.com/c/titanic/data
 category: SocialSciences
 description:
 version:
@@ -22,8 +22,8 @@ issued_time:
 sources:
   - title: Titanic Survival Data Set on Kaggle
     access_url: https://www.kaggle.com/c/titanic/data
-    download_url:
-    format:
+    download_url: https://github.com/awesomedata/awesome-public-datasets/tree/master/Datasets
+    format: zip
     media_type:
     schema:
 


### PR DESCRIPTION
Update the link address redirected to Kaggle:


This dataset was downloaded from public Web. https://www.kaggle.com/c/titanic/data
I saved this data in the repository as backup because I felt this data is valuable and not widely found on the Web.
Please refer to the original license of the dataset.
