### PR TITLE
Add congressional twitter dataset

### DIFF
--- a/core/SocialNetworks/United-States-Congressional-Twitter-Data.yml
+++ b/core/SocialNetworks/United-States-Congressional-Twitter-Data.yml
@@ -1,0 +1,22 @@
+---
+title: United States Congress Twitter Data
+homepage: https://github.com/alexlitel/congresstweets
+category: SocialNetworks
+description: Daily datasets with tweets of 1100+ accounts associated with the House of Representatives and Senate, including members, committees, and more.
+version:
+keywords:
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language:
+license:
+publisher:
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
---
title: CongressTweets
homepage: https://github.com/alexlitel/congresstweets
category: SocialNetworks
description: Daily datasets with tweets of 1100+ accounts associated with the House of Representatives and Senate, including members, committees, and more.
keywords: congress, twitter, us politics
image: 
temporal:
spatial:
access_level: public
copyrights:
accrual_periodicity: Daily
specification:
data_quality: false
data_dictionary: 
language: en
license: MIT
publisher:
  - name: 
    web: 
organization:
  - name:
    web: 
issued_time:
sources:
  - name: 
    access_url: 
references:
  - title: 
    reference: 