### PR TITLE
Add OpenDota data dump

### DIFF
--- a/core/eSports/opendota-dump.yml
+++ b/core/eSports/opendota-dump.yml
@@ -1,0 +1,22 @@
+---
+title: OpenDota data dump
+homepage: https://blog.opendota.com/2017/03/24/datadump2/
+category: eSports
+description:
+version:
+keywords: Dota 2
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language:
+license:
+publisher:
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
Greetings. This adds the OpenDota data dump from 2016, contains data about over a million dota 2 matches. In the page linked, minor versions of the dataset are available for download (4GB), as well as (much) bigger datasets (150+GB) hosted by [academictorrents.com](https://blog.opendota.com/2017/03/24/datadump2/).

IMHO it makes sense to put it under a new category but let me know otherwise.

Cheers.

---
title: OpenDota data dump
homepage: https://blog.opendota.com/2017/03/24/datadump2/
category: eSports
description:
version:
keywords: Dota 2
image:
temporal:
spatial:
access_level:
copyrights:
accrual_periodicity:
specification:
data_quality: false
data_dictionary:
language:
license:
publisher:
organization:
issued_time:
sources: []