### PR TITLE
Update dead link

### DIFF
--- a/core/Government/OpenDataSofts-list-of-1600-open-data.yml
+++ b/core/Government/OpenDataSofts-list-of-1600-open-data.yml
@@ -1,6 +1,6 @@
 ---
 title: OpenDataSoft's list of 1,600 open data
-homepage: https://www.opendatasoft.com/a-comprehensive-list-of-all-open-data-portals-around-the-world/
+homepage: https://www.opendatasoft.com/blog/2015/11/02/how-we-put-together-a-list-of-1600-open-data-portals-around-the-world-to-help-open-data-community
 category: Government
 description:
 version:


### PR DESCRIPTION
The previous link was dead (redirected to the homepage) since the blog post was republished. I added its new URL instead.