### PR TITLE
Add New York State Education Department Data under Education

### DIFF
--- a/core/Education/New-York-State-Education-Department.yml
+++ b/core/Education/New-York-State-Education-Department.yml
@@ -1,0 +1,31 @@
+---
+title: New York State Education Department Data
+homepage: https://data.nysed.gov/downloads.php
+category: Education
+description: The New York State Education Department (NYSED) is committed to making data available and easy to use. This site provides a first step in publicly reporting educational data so all interested parties can be better informed as they work to advance student achievement.
+version: 
+keywords: higher education, school, county, district
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity: 
+specification:
+data_quality: false
+data_dictionary: 
+language: en
+license:
+publisher:
+  - name: 
+    web: 
+organization:
+  - name: New York State Education Department
+    web: https://data.nysed.gov/
+issued_time: 
+sources:
+  - name: 
+    access_url: 
+references:
+  - title: 
+    reference: 


### PR DESCRIPTION
Hi, I added New York State Education Data under Education topic. Here is the yml file:


```
---
title: New York State Education Department Data
homepage: https://data.nysed.gov/downloads.php
category: Education
description: The New York State Education Department (NYSED) is committed to making data available and easy to use. This site provides a first step in publicly reporting educational data so all interested parties can be better informed as they work to advance student achievement.
version:
keywords: higher education, school, county, district
image:
temporal:
spatial:
access_level:
copyrights:
accrual_periodicity:
specification:
data_quality: false
data_dictionary:
language: en
license:
publisher:
  - name:
    web:
organization:
  - name: New York State Education Department
    web: https://data.nysed.gov/
issued_time:
sources:
  - name:
    access_url:
references:
  - title:
    reference:
```