### PR TITLE
Fix link to UK-DALE.

### DIFF
--- a/core/Energy/UK-DALE.yml
+++ b/core/Energy/UK-DALE.yml
@@ -1,6 +1,6 @@
 ---
 title: UK-DALE
-homepage: http://www.doc.ic.ac.uk/~dk3810/data/
+homepage: https://jack-kelly.com/data
 category: Energy
 description: UK Domestic Appliance-Level Electricity
 version:
@@ -12,7 +12,7 @@ access_level:
 copyrights:
 accrual_periodicity:
 specification:
-data_quality: false
+data_quality: true
 data_dictionary:
 language:
 license:


### PR DESCRIPTION
Closes #148

---
title: 38-Cloud
homepage: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset
category: EarthScience
description: Contains 38 Landsat 8 scene images and their manually extracted pixel-level ground truths for cloud detection. They are cropped into multiple 384*384 patches. It has 8400 patches for training and 9201 patches for testing.
version: 1.0
keywords: Landsat 8, cloud detection, image segmentation, semantic segmentation.
image: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset/blob/master/sample/blue_patch_192_10_by_12_LC08_L1TP_002053_20160520_20170324_01_T1.jpg
temporal:
spatial: 384*384
access_level: public
copyrights:
accrual_periodicity: 
specification:
data_quality: false
data_dictionary: 
language: en
license: Apache License
publisher:
  - name: 
    web: 
organization:
  - name: Laboratory for Robotic Vision (LRV), School of Engineering Science, Simon Fraser University, Canada
    web: 
issued_time: 2019.02
sources:
  - name: 
    access_url: 
references:
  - title: 
    reference: 
