### PR TITLE
Add DEL to Energy

### DIFF
--- a/core/Energy/DEL.yml
+++ b/core/Energy/DEL.yml
@@ -7,7 +7,7 @@ version:
 keywords: household, energy, consumption, load, profiles, residential, South, Africa
 image: https://github.com/wiebket/delprocess/blob/master/delprocess/data/images/DEL_logo.png
 temporal: 5 min
-spatial: 
+spatial: GPS coordinates, street level
 access_level: 
 copyrights:
 accrual_periodicity: 
@@ -17,12 +17,12 @@ data_dictionary:
 language: en
 license: CC BY-NC
 publisher:
+  - name: Data First
+    web: https://www.datafirst.uct.ac.za/
+organization:
   - name: 
     web: 
-organization:
-  - name: Laboratory for Robotic Vision (LRV), School of Engineering Science, Simon Fraser University, Canada
-    web: 
-issued_time: 2019.02
+issued_time: 2019.05
 sources:
   - name: 
     access_url: 

--- a/core/Energy/DEL.yml
+++ b/core/Energy/DEL.yml
@@ -1,0 +1,31 @@
+---
+title: DEL
+homepage: https://www.datafirst.uct.ac.za/dataportal/index.php/catalog/DELS
+category: Energy
+description: Domestic Electrical Load study datsets for South Africa (1994 - 2014)
+version: 
+keywords: household, energy, consumption, load, profiles, residential, South, Africa
+image: https://github.com/wiebket/delprocess/blob/master/delprocess/data/images/DEL_logo.png
+temporal: 5 min
+spatial: 
+access_level: 
+copyrights:
+accrual_periodicity: 
+specification:
+data_quality: true
+data_dictionary: 
+language: en
+license: CC BY-NC
+publisher:
+  - name: 
+    web: 
+organization:
+  - name: Laboratory for Robotic Vision (LRV), School of Engineering Science, Simon Fraser University, Canada
+    web: 
+issued_time: 2019.02
+sources:
+  - name: 
+    access_url: 
+references:
+  - title: 
+    reference: 


### PR DESCRIPTION
Added Domestic Electrical Load datasets for South Africa (1994 - 2014). Research use only (non-commercial).