### PR TITLE
Add PEM1 under energy

### DIFF
--- a/core/Energy/PEM1.yml
+++ b/core/Energy/PEM1.yml
@@ -1,0 +1,22 @@
+---
+title: PEM1
+homepage: https://github.com/ECSIM/pem-dataset1
+category: Energy
+description: Proton Exchange Membrane (PEM) Fuel Cell Dataset
+version:
+keywords:
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language:
+license:
+publisher:
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
---
title: PEM1
homepage: https://github.com/ECSIM/pem-dataset1
category: Energy
description: Proton Exchange Membrane (PEM) Fuel Cell Dataset
version:
keywords:
image:
temporal:
spatial:
access_level:
copyrights:
accrual_periodicity:
specification:
data_quality: false
data_dictionary:
language:
license:
publisher:
organization:
issued_time:
sources: []
