### PR TITLE
Fix tests by specifcying loader

### DIFF
--- a/tests/validate.py
+++ b/tests/validate.py
@@ -27,7 +27,7 @@ def validate_classification(category_map):
     for category, entries in category_map.items():
         for entry in entries:
             try:
-                data_obj = yaml.load(open(entry))
+                data_obj = yaml.load(open(entry), Loader=yaml.Loader)
             except Exception as e:
                 raise RuntimeError('Failed to read YAML data: {}'.format(e))
 


### PR DESCRIPTION
I realized we have the build failing icon on the front page. Looks like it was failing due to  

> ./tests/validate.py:30: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.

This fixes that issue