### PR TITLE
Fix ghtorrent link

### DIFF
--- a/core/Software/GHTorrent.yml
+++ b/core/Software/GHTorrent.yml
@@ -1,6 +1,6 @@
 ---
 title: GHTorrent
-homepage: ghtorrent.org
+homepage: https://ghtorrent.org
 category: Software
 description: Scalable, queriable, offline mirror of data offered through the Github REST API.
 version: 1.0


### PR DESCRIPTION
Use the full URL for ghtorrent so that the link doesn't 404 in the generated markdown. Closes https://github.com/awesomedata/awesome-public-datasets/issues/388.