### PR TITLE
Created FIFA-2021 in eSports

### DIFF
--- a/core/eSports/fifa2021.yml
+++ b/core/eSports/fifa2021.yml
@@ -14,7 +14,7 @@ accrual_periodicity:
 specification:
 data_quality: false
 data_dictionary:
-language:English
+language: en
 license:
 publisher:
 organization:

--- a/core/eSports/fifa2021.yml
+++ b/core/eSports/fifa2021.yml
@@ -1,0 +1,22 @@
+---
+title: FIFA-2021 Complete Player Dataset
+homepage: https://www.kaggle.com/aayushmishra1512/fifa-2021-complete-player-data
+category: eSports
+description:
+version:
+keywords: FIFA-2021
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language:English
+license:
+publisher:
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
---
title: FIFA-2021 Complete Player Dataset
homepage: https://www.kaggle.com/aayushmishra1512/fifa-2021-complete-player-data
category: eSports
description:
version:
keywords: FIFA-2021
image:
temporal:
spatial:
access_level:
copyrights:
accrual_periodicity:
specification:
data_quality: false
data_dictionary:
language:English
license:
publisher:
organization:
issued_time:
sources: []