### PR TITLE
Fix German Political Speeches Corpus broken link

### DIFF
--- a/core/NaturalLanguage/German-Political-Speeches-Corpus.yml
+++ b/core/NaturalLanguage/German-Political-Speeches-Corpus.yml
@@ -1,6 +1,6 @@
 ---
 title: German Political Speeches Corpus
-homepage: purl.org/corpus/german-speeches
+homepage: http://adrien.barbaresi.eu/corpora/speeches/
 category: NaturalLanguage
 description: Collection of political speeches from the German Presidency, Presidency of the Bundestag, Chancellery, and Ministry of Foreign Affairs
 version: 3.0


### PR DESCRIPTION
The link "German Political Speeches Corpus - Collection of political speeches from [...]" currently goes to https://github.com/awesomedata/awesome-public-datasets/blob/master/purl.org/corpus/german-speeches on https://github.com/awesomedata/awesome-public-datasets/blob/master/README.rst.

This PR changes it to go to http://adrien.barbaresi.eu/corpora/speeches/, which redirects from https://purl.org/corpus/german-speeches.