### PR TITLE
Fix typos in descriptions

### DIFF
--- a/core/Agriculture/Global-dataset-of-historical-yields-for-major-crops.yml
+++ b/core/Agriculture/Global-dataset-of-historical-yields-for-major-crops.yml
@@ -2,7 +2,7 @@
 title: The global dataset of historical yields for major crops 1981–2016
 homepage: https://doi.pangaea.de/10.1594/PANGAEA.909132
 category: Agriculture
-description: "The Global Dataset of Historical Yield (GDHYv1.2+v1.3) offers annual time series data of 0.5-degree grid-cell yield estimates of major crops worldwide for the period 1981-2016. The crops considered in this dataset are maize, rice, wheat and soybean. The unit of yield data is t/ha. The grd-cell yield data were estimated using the satellite-derived crop-specific vegetation index and FAO-reported country yield statistics. Maize and rice have the data for each of two growing seasons (major/secondary). 'Winter' and 'spring' are used as the growing season categories for wheat. Only 'major' growing season is available for soybean. These growing season categories are based on Sacks et al. (2010, DOI: 10.1111/j.1466-8238.2010.00551.x)."
+description: "The Global Dataset of Historical Yield (GDHYv1.2+v1.3) offers annual time series data of 0.5-degree grid-cell yield estimates of major crops worldwide for the period 1981-2016. The crops considered in this dataset are maize, rice, wheat and soybean. The unit of yield data is t/ha. The grid-cell yield data were estimated using the satellite-derived crop-specific vegetation index and FAO-reported country yield statistics. Maize and rice have the data for each of two growing seasons (major/secondary). 'Winter' and 'spring' are used as the growing season categories for wheat. Only 'major' growing season is available for soybean. These growing season categories are based on Sacks et al. (2010, DOI: 10.1111/j.1466-8238.2010.00551.x)."
 version: 1.0
 keywords: crop
 temporal:

--- a/core/Agriculture/Lemon-Dataset.yml
+++ b/core/Agriculture/Lemon-Dataset.yml
@@ -4,7 +4,7 @@ homepage: https://github.com/softwaremill/lemon-dataset
 category: Agriculture
 description: Lemon dataset has been prepared to investigate the possibilities to tackle the issue of fruit quality control. It contains 2690 annotated images (1056 x 1056 pixels)
 version: 1.0.0
-keywords: fruit, quality, lemon, segementation
+keywords: fruit, quality, lemon, segmentation
 image: https://github.com/softwaremill/lemon-dataset/blob/master/docs/img/lemon-dataset-annotated-sprite.png
 access_level: public
 language: en

--- a/core/Biology/ICOS-PSP-Benchmark.yml
+++ b/core/Biology/ICOS-PSP-Benchmark.yml
@@ -2,7 +2,7 @@
 title: ICOS PSP Benchmark
 homepage: http://ico2s.org/datasets/psp_benchmark.html
 category: Biology
-description: The ICOS PSP benchmarks repository contains an adjustable real-world family of benchmarks suitable for testing the scalability of classification/regression methods. When we test a machine learning method we usually choose a test suite containing datasets with a broad set of characteristics, as we are interested in knowing how the learning method reacts to a veriety of scenarios. The PSP field provides us with a whole family of real-world classification/regression problems that can be adjusted almost arbitrarily in terms of number of variables, number of classes, class balance, etc. Thus, these datasets are an ideal benchmark suite for data mining methods.
+description: The ICOS PSP benchmarks repository contains an adjustable real-world family of benchmarks suitable for testing the scalability of classification/regression methods. When we test a machine learning method we usually choose a test suite containing datasets with a broad set of characteristics, as we are interested in knowing how the learning method reacts to a variety of scenarios. The PSP field provides us with a whole family of real-world classification/regression problems that can be adjusted almost arbitrarily in terms of number of variables, number of classes, class balance, etc. Thus, these datasets are an ideal benchmark suite for data mining methods.
 version:
 keywords:
 image:

--- a/core/Climate+Weather/Dutch-Weather.yml
+++ b/core/Climate+Weather/Dutch-Weather.yml
@@ -2,7 +2,7 @@
 title: Dutch Weather
 homepage: https://data.knmi.nl/datasets
 category: Climate+Weather
-description: The KNMI Data Center (KDC) portal provides access to KNMI data on weather, climate and seismology. You will find KNMI data on various topicssuch as the most recent 10 minutes of automated weather observations, historical data, data on meteorological stations, model output, earthquake data and satellite products.
+description: The KNMI Data Center (KDC) portal provides access to KNMI data on weather, climate and seismology. You will find KNMI data on various topics such as the most recent 10 minutes of automated weather observations, historical data, data on meteorological stations, model output, earthquake data and satellite products.
 version: 1.0
 keywords: Weather, Climate, Seismology
 image:

--- a/core/EarthScience/NERRS-SWMP.yml
+++ b/core/EarthScience/NERRS-SWMP.yml
@@ -20,7 +20,7 @@ publisher:
   - name: NOAA NERRS Centralized Data Management Office
     web: http://nerrsdata.org
 organization:
-  - name: NOAA Natioanal Estuarine Research Reserve System
+  - name: NOAA National Estuarine Research Reserve System
     web: https://coast.noaa.gov/nerrs/
 issued_time: 
 sources:

--- a/core/EarthScience/Oil-and-Gas-Authority-UK.yml
+++ b/core/EarthScience/Oil-and-Gas-Authority-UK.yml
@@ -15,7 +15,7 @@ specification:
 data_quality: true 
 data_dictionary:
 language:
-license: Open Government Licence
+license: Open Government License
 publisher: Oil and Gas Authority, UK
 organization: Oil and Gas Authority, UK
 issued_time: 2019-03-25

--- a/core/Economics/The-Center-for-International-Data.yml
+++ b/core/Economics/The-Center-for-International-Data.yml
@@ -19,4 +19,4 @@ license:
 publisher:
 organization:
 issued_time:
-sources: [enquired about dead URL on 12/18/2018 - emailed dept and Dr. Feenstra]
+sources: [inquired about dead URL on 12/18/2018 - emailed dept and Dr. Feenstra]

--- a/core/GIS/TZ-Timezones-shapfiles.yml
+++ b/core/GIS/TZ-Timezones-shapfiles.yml
@@ -1,5 +1,5 @@
 ---
-title: TZ Timezones shapfiles
+title: TZ Timezones shapefile
 homepage: http://efele.net/maps/tz/world/
 category: GIS
 description:

--- a/core/Government/Metropolitain-Transportation-Commission-MTC-California-US.yml
+++ b/core/Government/Metropolitain-Transportation-Commission-MTC-California-US.yml
@@ -1,5 +1,5 @@
 ---
-title: Metropolitain Transportation Commission (MTC), California, US
+title: Metropolitan Transportation Commission (MTC), California, US
 homepage: http://mtc.ca.gov/tools-resources/data-tools/open-data-library
 category: Government
 description:

--- a/core/Government/Missisauga-ON-Canada.yml
+++ b/core/Government/Missisauga-ON-Canada.yml
@@ -1,5 +1,5 @@
 ---
-title: Missisauga, ON, Canada
+title: Mississauga, ON, Canada
 homepage: http://www.mississauga.ca/portal/residents/publicationsopendatacatalogue
 category: Government
 description:

--- a/core/Healthcare/Yahoo-COVID-19.yml
+++ b/core/Healthcare/Yahoo-COVID-19.yml
@@ -2,7 +2,7 @@
 title: Yahoo Knowledge Graph COVID-19 Datasets
 homepage: https://github.com/yahoo/covid-19-data
 category: Healthcare
-description: The Yahoo Knowledge Graph team at Verizon Media is responsible for providing critical COVID-19 data that feeds into Yahoo properties like Yahoo News, Yahoo Finance, and Yahoo Weather. The COVID-19 datasets include country, state, and county level information updated on a rolling basis, with updates occuring approximately hourly.
+description: The Yahoo Knowledge Graph team at Verizon Media is responsible for providing critical COVID-19 data that feeds into Yahoo properties like Yahoo News, Yahoo Finance, and Yahoo Weather. The COVID-19 datasets include country, state, and county level information updated on a rolling basis, with updates occurring approximately hourly.
 version: 1.0
 keywords: covid-19
 access_level: public

--- a/core/ImageProcessing/Adience-Unfiltered-faces-for-gender-and-age-classification.yml
+++ b/core/ImageProcessing/Adience-Unfiltered-faces-for-gender-and-age-classification.yml
@@ -1,5 +1,5 @@
 ---
-title: Adience Unfiltered faces for gender and age classification
+title: Audience Unfiltered faces for gender and age classification
 homepage: http://www.openu.ac.il/home/hassner/Adience/data.html
 category: ImageProcessing
 description:

--- a/core/ImageProcessing/SVIRO.yml
+++ b/core/ImageProcessing/SVIRO.yml
@@ -2,7 +2,7 @@
 title: SVIRO Synthetic Vehicle Interior Rear Seat Occupancy 
 homepage: https://sviro.kl.dfki.de
 category: ImageProcessing
-description: 25.000 synthetic sceneries across ten different vehicle interiors for several simulated sensor inputs and ground truth data
+description: 25.000 synthetic scenery's across ten different vehicle interiors for several simulated sensor inputs and ground truth data
 version: 1.0
 keywords: Automotive, classification, object detection, instance segmentation, pose estimation, seat occupancy
 image: https://sviro.kl.dfki.de/wp-content/uploads/2019/11/web_front_rgb-768x512.png

--- a/core/Neuroscience/NeuroMorpho.yml
+++ b/core/Neuroscience/NeuroMorpho.yml
@@ -3,7 +3,7 @@ title: NeuroMorpho
 homepage: http://neuromorpho.org/
 category: Neuroscience
 description: NeuroMorpho.Org is a centrally curated inventory of digitally reconstructed neurons associated with peer-reviewed publications. It contains contributions from over 400 laboratories worldwide and is continuously updated as new morphological reconstructions are collected, published, and shared. To date, NeuroMorpho.Org is the largest collection of publicly accessible 3D neuronal reconstructions and associated metadata.
-ersion: 7.5
+version: 7.5
 keywords: Neuron, morphology
 image:
 temporal:

--- a/core/Software/GHTorrent.yml
+++ b/core/Software/GHTorrent.yml
@@ -2,7 +2,7 @@
 title: GHTorrent
 homepage: https://ghtorrent.org
 category: Software
-description: Scalable, queriable, offline mirror of data offered through the Github REST API.
+description: Scalable, queryable, offline mirror of data offered through the GitHub REST API.
 version: 1.0
 keywords: github, open source
 image: https://pbs.twimg.com/profile_images/580387012341010432/LpYCqgLJ_400x400.png

--- a/core/Software/source{d}-source-code-identifiers.yml
+++ b/core/Software/source{d}-source-code-identifiers.yml
@@ -2,7 +2,7 @@
 title: Source Code Identifiers
 homepage: https://github.com/src-d/datasets/tree/master/Identifiers
 category: Software
-description: 41.7 million distinct splittable identifiers collected from 182,014 open source projects in Public Git Archive
+description: 41.7 million distinct split table identifiers collected from 182,014 open source projects in Public Git Archive
 version:
 keywords: source code, git, GitHub, software repositories, development history, open dataset
 image:

--- a/core/Software/source{d}-source-code-identifiers.yml
+++ b/core/Software/source{d}-source-code-identifiers.yml
@@ -2,7 +2,7 @@
 title: Source Code Identifiers
 homepage: https://github.com/src-d/datasets/tree/master/Identifiers
 category: Software
-description: 41.7 million distinct split table identifiers collected from 182,014 open source projects in Public Git Archive
+description: 41.7 million distinct splittable identifiers collected from 182,014 open source projects in Public Git Archive
 version:
 keywords: source code, git, GitHub, software repositories, development history, open dataset
 image:

--- a/core/Sports/Pro_Kabadi_season1_7.yml
+++ b/core/Sports/Pro_Kabadi_season1_7.yml
@@ -2,7 +2,7 @@
 title: Pro Kabadi season 1 to 7
 homepage: https://github.com/ranganadhkodali/Pro-Kabadi-season-1-7-Stats
 category: Sports
-description: Pro Kabadi League is a professional-level Kabaddi league in India. Data Set contains the match level stats from the seasion 1 to 7. data set include player level stats and match level stats including points earned and key match events.
+description: Pro Kabadi League is a professional-level Kabaddi league in India. Dataset contains the match level stats from the seasons 1 to 7. Dataset includes player level stats and match level stats including points earned and key match events.
 version: 1.0
 keywords: Pro Kabadi,ProKabadi,Kabadi,Sports DataSet,indian sports
 image: https://www.prokabaddi.com/static-assets/images/cssimages/prokabaddi-logo.png


### PR DESCRIPTION
There are a few typos in the descriptions, as well as some minor grammar fixes which were fixed in this PR. The filenames which have typos are unchanged (e.g. `Missisauga-ON-Canada.yml`).