### PR TITLE
Add Ably Open Realtime Data under PublicDomains

### DIFF
--- a/core/PublicDomains/Ably.yml
+++ b/core/PublicDomains/Ably.yml
@@ -1,0 +1,22 @@
+---
+title: Ably Open Realtime Data
+homepage: https://www.ably.io/hub/
+category: PublicDomains
+description:
+version:
+keywords:
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language:
+license:
+publisher:
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
Adds Ably Hub, open source of realtime data from any sector to PublicDomains.