### PR TITLE
Add Iranis dataset

### DIFF
--- a/core/MachineLearning/Iranis.yml
+++ b/core/MachineLearning/Iranis.yml
@@ -1,0 +1,31 @@
+---
+title: Iranis
+homepage: https://alitourani.github.io/Iranis-dataset/
+category: MachineLearning
+description: A Large-scale Dataset of Farsi/Arabic License Plate Characters
+version: 1.0
+keywords: machine learning, deep learning, license plate, farsi character, arabic character.
+image: https://raw.githubusercontent.com/alitourani/Iranis-dataset/master/_doc/Iranis_License_Plates.png
+temporal:
+spatial: 
+access_level: public
+copyrights:
+accrual_periodicity: 
+specification:
+data_quality: false
+data_dictionary: 
+language: en
+license: Apache License
+publisher:
+  - name: 
+    web: 
+organization:
+  - name: Technology Incubation Center of the University of Guilan, Guilan Province, Iran
+    web: 
+issued_time: 2021.01
+sources:
+  - name: 
+    access_url: 
+references:
+  - title: 
+    reference: 


### PR DESCRIPTION
---
title: 38-Cloud
homepage: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset
category: EarthScience
description: Contains 38 Landsat 8 scene images and their manually extracted pixel-level ground truths for cloud detection. They are cropped into multiple 384*384 patches. It has 8400 patches for training and 9201 patches for testing.
version: 1.0
keywords: Landsat 8, cloud detection, image segmentation, semantic segmentation.
image: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset/blob/master/sample/blue_patch_192_10_by_12_LC08_L1TP_002053_20160520_20170324_01_T1.jpg
temporal:
spatial: 384*384
access_level: public
copyrights:
accrual_periodicity: 
specification:
data_quality: false
data_dictionary: 
language: en
license: Apache License
publisher:
  - name: 
    web: 
organization:
  - name: Laboratory for Robotic Vision (LRV), School of Engineering Science, Simon Fraser University, Canada
    web: 
issued_time: 2019.02
sources:
  - name: 
    access_url: 
references:
  - title: 
    reference: 
