### PR TITLE
Add DBFC under energy

### DIFF
--- a/core/Energy/DBFC.yml
+++ b/core/Energy/DBFC.yml
@@ -1,0 +1,22 @@
+---
+title: DBFC
+homepage: https://github.com/ECSIM/dbfc-dataset
+category: Energy
+description: Direct Borohydride Fuel Cell (DBFC) Dataset
+version:
+keywords:
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language:
+license:
+publisher:
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
---
title: DBFC
homepage: https://github.com/ECSIM/dbfc-dataset
category: Energy
description: Direct Borohydride Fuel Cell (DBFC) Dataset
version:
keywords:
image:
temporal:
spatial:
access_level:
copyrights:
accrual_periodicity:
specification:
data_quality: false
data_dictionary:
language:
license:
publisher:
organization:
issued_time:
sources: []
