### PR TITLE
Add City of Berkeley Open Data under government

### DIFF
--- a/core/Government/Berkeley-CA-Open-Data.yml
+++ b/core/Government/Berkeley-CA-Open-Data.yml
@@ -1,0 +1,4 @@
+---
+title: City of Berkeley Open Data
+homepage: https://data.cityofberkeley.info/
+category: Government


### PR DESCRIPTION
---
title: City of Berkeley Open Data
homepage: https://data.cityofberkeley.info/
category: Government