### PR TITLE
Add ETHEC dataset under ImageProcessing

### DIFF
--- a/core/ImageProcessing/ETH_Entomological_Collection_Fine_Grained_Butterfly_Images.yml
+++ b/core/ImageProcessing/ETH_Entomological_Collection_Fine_Grained_Butterfly_Images.yml
@@ -1,0 +1,23 @@
+---
+title: ETH Entomological Collection (ETHEC) Fine Grained Butterfly (Lepidoptra) Images
+homepage: https://doi.org/10.3929/ethz-b-000365379
+category: ImageProcessing
+description: 
+version:
+keywords: fine grained image classification, multi-label classification, image classification, hierarchical labels, lepidoptra, butterflies, natural images
+image: 
+temporal:
+spatial: 
+access_level: public
+copyrights:
+accrual_periodicity: 
+specification:
+data_quality:
+data_dictionary:
+language: en
+license: IN COPYRIGHT - NON-COMMERCIAL USE PERMITTED
+publisher:
+organization:
+issued_time: 
+sources: []
+references:


### PR DESCRIPTION
---
title: ETH Entomological Collection (ETHEC) Fine Grained Butterfly (Lepidoptra) Images
homepage: https://doi.org/10.3929/ethz-b-000365379
category: ImageProcessing
description: 
version:
keywords: fine grained image classification, multi-label classification, image classification, hierarchical labels, lepidoptra, butterflies, natural images
image: 
temporal:
spatial: 
access_level: public
copyrights:
accrual_periodicity: 
specification:
data_quality:
data_dictionary:
language: en
license: IN COPYRIGHT - NON-COMMERCIAL USE PERMITTED
publisher:
organization:
issued_time: 
sources: []
references: