### PR TITLE
Added AndMal2020 under CyberSecurity

### DIFF
--- a/core/CyberSecurity/CCCS-CIC-AndMal-2020.yml
+++ b/core/CyberSecurity/CCCS-CIC-AndMal-2020.yml
@@ -1,0 +1,30 @@
+---
+title: CCCS-CIC-AndMal-2020
+homepage: https://www.unb.ca/cic/datasets/andmal2020.html
+category: CyberSecurity
+description: The dataset includes 200K benign and 200K malware samples totalling to 400K android apps with 14 prominent malware categories and 191 eminent malware families.
+keywords: Landsat 8, cloud detection, image segmentation, semantic segmentation.
+image: 
+temporal:
+spatial: 
+access_level: public
+copyrights:
+accrual_periodicity: 
+specification:
+data_quality:
+data_dictionary: 
+language: en
+license: Apache License
+publisher:
+  - name: 
+    web: 
+organization:
+  - name: Canadian Institute for Cybersecurity, University of New Brunswick, Canada
+    web: 
+issued_time: 2020
+sources:
+  - name: 
+    access_url: 
+references:
+  - title: DIDroid- "Android Malware Classification and Characterization Using Deep Image Learning" Abir Rahali et al 2020
+    reference: 


### PR DESCRIPTION
---
title: 38-Cloud
homepage: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset
category: EarthScience
description: Contains 38 Landsat 8 scene images and their manually extracted pixel-level ground truths for cloud detection. They are cropped into multiple 384*384 patches. It has 8400 patches for training and 9201 patches for testing.
version: 1.0
keywords: Landsat 8, cloud detection, image segmentation, semantic segmentation.
image: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset/blob/master/sample/blue_patch_192_10_by_12_LC08_L1TP_002053_20160520_20170324_01_T1.jpg
temporal:
spatial: 384*384
access_level: public
copyrights:
accrual_periodicity: 
specification:
data_quality: false
data_dictionary: 
language: en
license: Apache License
publisher:
  - name: 
    web: 
organization:
  - name: Laboratory for Robotic Vision (LRV), School of Engineering Science, Simon Fraser University, Canada
    web: 
issued_time: 2019.02
sources:
  - name: 
    access_url: 
references:
  - title: 
    reference: 
