### PR TITLE
Update DBPedia's core dataset url

### DIFF
--- a/core/NaturalLanguage/DBpedia.yml
+++ b/core/NaturalLanguage/DBpedia.yml
@@ -1,6 +1,6 @@
 ---
-title: DBpedia - 4.58M things with 583M facts
-homepage: http://wiki.dbpedia.org/Datasets
+title: DBpedia - Structured data from Wikipedia
+homepage: https://databus.dbpedia.org/dbpedia/collections/latest-core
 category: NaturalLanguage
 description:
 version:


### PR DESCRIPTION
---
title: DBpedia - Structured data from Wikipedia
homepage: https://databus.dbpedia.org/dbpedia/collections/latest-core
category: NaturalLanguage