### PR TITLE
Update UC-Riverside-Time-Series-Dataset.yml

### DIFF
--- a/core/TimeSeries/UC-Riverside-Time-Series-Dataset.yml
+++ b/core/TimeSeries/UC-Riverside-Time-Series-Dataset.yml
@@ -1,6 +1,6 @@
 ---
 title: UC Riverside Time Series Dataset
-homepage: http://www.cs.ucr.edu/~eamonn/time_series_data/
+homepage: https://www.cs.ucr.edu/~eamonn/time_series_data_2018/
 category: TimeSeries
 description:
 version:


### PR DESCRIPTION
Updates the link from the discontinued version of the UCR archive to the extended dataset archive. 
