### PR TITLE
Correct deprecated link

### DIFF
--- a/core/DataChallenges/Netflix-Prize.yml
+++ b/core/DataChallenges/Netflix-Prize.yml
@@ -1,6 +1,6 @@
 ---
 title: Netflix Prize
-homepage: http://netflixprize.com/leaderboard.html
+homepage: https://www.kaggle.com/datasets/netflix-inc/netflix-prize-data
 category: DataChallenges
 description:
 version:


### PR DESCRIPTION
Previous Netflix Challenge link is now redirecting to Netflix main website