### PR TITLE
add new 42k appartment model dataset

### DIFF
--- a/core/Architecture/appartment-models.yml
+++ b/core/Architecture/appartment-models.yml
@@ -1,0 +1,31 @@
+---
+title: Swiss Appartment Models
+homepage: https://zenodo.org/record/7070952#.Y0mACy0RqO0
+category: Architecture
+description: This dataset contains detailed data on 42,207 apartments (242,257 rooms) in 3,093 buildings including their geometries, room typology as well as their visual, acoustical, topological and daylight characteristics.
+version: 1.0
+keywords: building plans, layout, view, sun exposure, Switzerland, real estate
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity: 
+specification:
+data_quality: false
+data_dictionary: 
+language: en
+license: Creative Commons Attribution 4.0 International
+publisher:
+  - name: 
+    web: 
+organization:
+  - name: Archilyse AG, Switzerland
+    web: 
+issued_time: 2022.09.20
+sources:
+  - name: 
+    access_url: 
+references:
+  - title: 
+    reference: 


### PR DESCRIPTION
---
title: 38-Cloud
homepage: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset
category: EarthScience
description: Contains 38 Landsat 8 scene images and their manually extracted pixel-level ground truths for cloud detection. They are cropped into multiple 384*384 patches. It has 8400 patches for training and 9201 patches for testing.
version: 1.0
keywords: Landsat 8, cloud detection, image segmentation, semantic segmentation.
image: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset/blob/master/sample/blue_patch_192_10_by_12_LC08_L1TP_002053_20160520_20170324_01_T1.jpg
temporal:
spatial: 384*384
access_level: public
copyrights:
accrual_periodicity: 
specification:
data_quality: false
data_dictionary: 
language: en
license: Apache License
publisher:
  - name: 
    web: 
organization:
  - name: Laboratory for Robotic Vision (LRV), School of Engineering Science, Simon Fraser University, Canada
    web: 
issued_time: 2019.02
sources:
  - name: 
    access_url: 
references:
  - title: 
    reference: 
