### PR TITLE
Added WHPA (wellhead protection area) dataset in the Earth Science ca…

### DIFF
--- a/core/EarthScience/WHPA.yml
+++ b/core/EarthScience/WHPA.yml
@@ -1,0 +1,31 @@
+---
+title: Wellhead Protection Area (protection zone) prediction using breakthrough curves
+homepage: https://www.kaggle.com/datasets/robustus/whpa-prediction
+category: EarthScience
+description: This dataset contains 4148 simulation results, i.e., 4148 pairs of predictor/target. bkt.npy contains the breakthrough curves from all 6 injection wells recorded at the pumping well. pz.npy contains the 2D coordinates of the backtracked particles' end points, used to delineate the WHPA.
+version: 1.0
+keywords: whpa, breakthrough curves, particle tracking, machine learning
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: true
+data_dictionary: 
+language: en
+license: CC BY-SA 4.0
+publisher:
+  - name: Kaggle
+    web: https://www.kaggle.com/datasets/robustus/whpa-prediction
+organization:
+  - name: Laboratory for Applied Geology and Hydrogeology, Ghent University, Belgium
+    web: https://www.ugent.be/we/geologie/en/research/organization/applied-geology-and-hydrogeology
+issued_time: 2022.10
+sources:
+  - name:
+    access_url:
+references:
+  - title: A new framework for experimental design using Bayesian Evidential Learning--the case of wellhead protection area
+    reference: https://doi.org/10.1016/j.jhydrol.2021.126903


### PR DESCRIPTION
…tegory.

---
title: 38-Cloud
homepage: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset
category: EarthScience
description: Contains 38 Landsat 8 scene images and their manually extracted pixel-level ground truths for cloud detection. They are cropped into multiple 384*384 patches. It has 8400 patches for training and 9201 patches for testing.
version: 1.0
keywords: Landsat 8, cloud detection, image segmentation, semantic segmentation.
image: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset/blob/master/sample/blue_patch_192_10_by_12_LC08_L1TP_002053_20160520_20170324_01_T1.jpg
temporal:
spatial: 384*384
access_level: public
copyrights:
accrual_periodicity: 
specification:
data_quality: false
data_dictionary: 
language: en
license: Apache License
publisher:
  - name: 
    web: 
organization:
  - name: Laboratory for Robotic Vision (LRV), School of Engineering Science, Simon Fraser University, Canada
    web: 
issued_time: 2019.02
sources:
  - name: 
    access_url: 
references:
  - title: 
    reference: 
