### PR TITLE
Add nba-sql under Sports

### DIFF
--- a/core/Sports/NBA-sql.yml
+++ b/core/Sports/NBA-sql.yml
@@ -1,0 +1,22 @@
+---
+title: nba-sql
+homepage: https://github.com/mpope9/nba-sql
+category: Sports
+description:
+version:
+keywords:
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language:
+license:
+publisher:
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
This adds a new NBA database to this repo.

Whenever I try the test suite on master I get an error, so I am not entirely sure if this runs correctly.
```
Scanned category: eSports
Traceback (most recent call last):
  File "/Users/pope/Projects/apd-core/./tests/validate.py", line 46, in <module>
    validate_classification(categories)
  File "/Users/pope/Projects/apd-core/./tests/validate.py", line 38, in validate_classification
    assert data_obj.get('category') == category
AssertionError
```

Note this is a python app that will build a DB locally, I don't provide the actual database files. But it is free and open source, no paywall or anything like that.