### PR TITLE
Add Gdańsk (PL) Open Data portal

### DIFF
--- a/core/Government/Gdansk-PL.yml
+++ b/core/Government/Gdansk-PL.yml
@@ -1,7 +1,7 @@
 resources:
-  - name: Gdańsk Open Data
+  - title: Gdańsk Open Data
     description: Official open data portal of the City of Gdańsk (Poland).
-    url: https://otwartedane.gdansk.pl/
+    homepage: https://otwartedane.gdansk.pl/
     category: Government
     type: city
     country: PL

--- a/core/Government/Gdansk-PL.yml
+++ b/core/Government/Gdansk-PL.yml
@@ -1,0 +1,8 @@
+resources:
+  - name: Gdańsk Open Data
+    description: Official open data portal of the City of Gdańsk (Poland).
+    url: https://otwartedane.gdansk.pl/
+    category: Government
+    type: city
+    country: PL
+    city: Gdańsk

--- a/core/Government/Gdansk-PL.yml
+++ b/core/Government/Gdansk-PL.yml
@@ -1,7 +1,7 @@
 resources:
   - title: Gdańsk Open Data
     description: Official open data portal of the City of Gdańsk (Poland).
-    homepage: https://otwartedane.gdansk.pl/
+    homepage: https://www.gdansk.pl/otwarte-dane-w-gdansku
     category: Government
     type: city
     country: PL

--- a/core/Government/Gdansk-PL.yml
+++ b/core/Government/Gdansk-PL.yml
@@ -1,7 +1,7 @@
 resources:
   - title: Gdańsk Open Data
-    description: Official open data portal of the City of Gdańsk (Poland).
     homepage: https://www.gdansk.pl/otwarte-dane-w-gdansku
+    description: "Official open data portal of the City of Gdańsk (Poland)."
     category: Government
     type: city
     country: PL

--- a/core/Government/Gdansk-PL.yml
+++ b/core/Government/Gdansk-PL.yml
@@ -1,5 +1,5 @@
 resources:
-  - title: Gdańsk Open Data
+  - title: Gdansk Open Data
     homepage: https://www.gdansk.pl/otwarte-dane-w-gdansku
     description: "Official open data portal of the City of Gdańsk (Poland)."
     category: Government


### PR DESCRIPTION
This PR adds the official Open Data portal of the City of Gdańsk (Poland).

- **Name:** Gdańsk Open Data
- **Description:** Official open data portal of the City of Gdańsk (Poland).
- **URL:** https://otwartedane.gdansk.pl/
- **Category:** Government
- **Type:** city
- **Country:** PL
- **City:** Gdańsk

This complements the previous contribution of Warsaw Open Data, continuing the inclusion of Polish municipal open data portals into the APD Core project.