### PR TITLE
Add MAP-VERSE metadata under GIS

### DIFF
--- a/core/GIS/map-verse.yml
+++ b/core/GIS/map-verse.yml
@@ -1,5 +1,5 @@
 ---
-title: MAP-VERSE: MAP usability - Validated Empirical Research by Systematic Evaluation
+title: MAP-VERSE - MAP usability - Validated Empirical Research by Systematic Evaluation
 homepage: https://map-verse.github.io/Repository/
 category: GIS
 description: >

--- a/core/GIS/map-verse.yml
+++ b/core/GIS/map-verse.yml
@@ -1,0 +1,22 @@
+---
+title: MAP-VERSE: MAP usability - Validated Empirical Research by Systematic Evaluation
+homepage: https://map-verse.github.io/Repository/
+category: GIS
+description: >
+  A curated metadata repository for map usability and spatial cognition studies.
+  Covers eye tracking, EEG/fMRI, and human sensing datasets collected during geospatial tasks.
+resources:
+  - name: GitHub Repository
+    url: https://github.com/MAP-VERSE/Repository
+  - name: Project Homepage
+    url: https://map-verse.github.io/Repository/
+tags:
+  - GIS
+  - maps
+  - eye-tracking
+  - EEG
+  - usability
+license: MIT
+notes: >
+  Index of external datasets and DOIs; does not host raw data.
+


### PR DESCRIPTION
---
This pull request adds MAP-VERSE to the GIS category.

MAP-VERSE (MAP usability - Validated Empirical Research by Systematic Evaluation) is an open-source metadata repository that indexes and standardizes empirical datasets in map usability and spatial cognition research. The repository provides curated metadata for datasets involving eye tracking, EEG/fMRI, and other human sensing methods collected during geospatial tasks.

- **Homepage:** https://map-verse.github.io/Repository/
- **GitHub Repository:** https://github.com/MAP-VERSE/Repository
- **Category:** GIS
- **License:** MIT

Notes:
MAP-VERSE does not host raw data; instead, it provides standardized metadata and links to external datasets (with DOIs where available). It is intended to support researchers seeking discoverable, comparable, and reusable resources in GIScience and usability studies.


