### PR TITLE
Add UNESCO Data Hub under Government category

### DIFF
--- a/core/Government/UNESCO-Data-Hub.yml
+++ b/core/Government/UNESCO-Data-Hub.yml
@@ -1,0 +1,38 @@
+# UNESCO Official Data Hub
+# File: ./core/Government/UNESCO-Data-Hub.yml
+
+title: UNESCO Data Hub
+homepage: https://data.unesco.org
+category: Government
+description: UNESCO's official data catalog providing authoritative global statistics across all UNESCO domains including education, culture, science, communication and information. The comprehensive data hub offers interactive datasets, visualizations, and indicators supporting evidence-based policymaking and sustainable development goals monitoring.
+keywords:
+  - education
+  - culture
+  - science
+  - communication
+  - information
+  - sustainable development goals
+  - SDG
+  - international organizations
+  - UNESCO
+  - UN
+  - global statistics
+  - policy data
+  - cultural heritage
+  - scientific cooperation
+language:
+  - English
+  - French
+  - Spanish
+  - Arabic
+license: Open Data
+format:
+  - CSV
+  - Excel
+  - JSON
+  - API
+  - Parquet
+  - GeoJSON
+region: Global
+source: UNESCO
+contact: data.ai@unesco.org


### PR DESCRIPTION
Adding UNESCO's official comprehensive data catalog to the Government category.

- **Homepage**: https://data.unesco.org
- **Description**: UNESCO's official data hub providing authoritative global statistics across education, culture, science, communication, and information domains
- **Formats**: CSV, Excel, JSON, API, Parquet, GeoJSON  
- **Languages**: English, French, Spanish, Arabic
- **Global scope**: Supporting SDG monitoring and evidence-based policymaking
- **Contact**: data.ai@unesco.org

This dataset meets high-quality criteria for academic, research, and educational communities.