### PR TITLE
Wireless Network Update

### DIFF
--- a/core/ComputerNetworks/CRAWDAD-Wireless-datasets-from-Dartmouth-Univ..yml
+++ b/core/ComputerNetworks/CRAWDAD-Wireless-datasets-from-Dartmouth-Univ..yml
@@ -2,7 +2,7 @@
 title: RF Jamming Dataset for Vehicular Wireless Networks
 homepage: https://ieee-dataport.org/documents/rf-jamming-dataset-vehicular-wireless-networks
 category: ComputerNetworks
-description: All the data from CRAWDAD has been moved to IEEE-dataport. This version is the updated version of the crawdad datasets.
+description: The RF Jamming Dataset for Vehicular Wireless Networks presents a comprehensive collection of data used in the research paper titled RF Jamming Classification Using Relative Speed Estimation in Vehicular Wireless Networks. This dataset comprises diverse scenarios of RF jamming attacks and interference in Vehicular Ad-hoc Networks (VANETs), along with corresponding ground truth labels.
 version:
 keywords: wireless network
 image:


### PR DESCRIPTION
CrawDAD database has been moved to IEEE data port including all its data in computer networks.

This is the data that bests fit the category and in CSV.