### PR TITLE
Add Congressional Stock Brain to Finance datasets

### DIFF
--- a/core/Finance/Congressional-Stock-Brain.yml
+++ b/core/Finance/Congressional-Stock-Brain.yml
@@ -1,0 +1,33 @@
+---
+title: Congressional Stock Brain
+homepage: https://congressionalstockbrain.com
+category: Finance
+description: Congressional Stock Brain is an AI-powered platform that ingests every U.S. STOCK Act disclosure (publicly filed lawmaker trades) and converts them into machine-scored trade signals for retail investors. Every disclosure is ranked by committee relevance, timing vs. legislative activity, trade size vs. historical baseline, and disclosure delay. Free to use, no login required.
+version: 1.0
+keywords: Finance, Government, STOCK Act, Congress, Lawmakers, Stock Trades, AI, Political Trading, Disclosure, Signals.
+image: https://congressionalstockbrain.com/favicon.ico
+temporal:
+spatial: United States
+access_level: public
+copyrights:
+accrual_periodicity: daily
+specification:
+data_quality: false
+data_dictionary: https://congressionalstockbrain.com/HowItWorks
+language: en
+license:
+publisher:
+  - name: Congressional Stock Brain
+      web: https://congressionalstockbrain.com
+      organization:
+        - name: Congressional Stock Brain
+            web: https://congressionalstockbrain.com
+            issued_time: 2026.01
+            sources:
+              - name: U.S. Senate Financial Disclosures
+                  access_url: https://efts.senate.gov/public/index.cfm/filings
+                    - name: U.S. House of Representatives Financial Disclosures
+                        access_url: https://disclosures.house.gov
+                        references:
+                          - title: STOCK Act (Stop Trading on Congressional Knowledge Act)
+                              reference: https://www.congress.gov/bill/112th-congress/senate-bill/2038


### PR DESCRIPTION
## Add Congressional Stock Brain to Finance datasets

This PR adds [Congressional Stock Brain](https://congressionalstockbrain.com) to the Finance category.

**What it is:** Congressional Stock Brain is a free, AI-powered platform that ingests every U.S. STOCK Act disclosure (publicly filed lawmaker trades) and converts them into machine-scored signals for retail investors. Every disclosure is ranked by:
- Committee relevance (does the lawmaker sit on a committee overseeing the industry?)
- - Timing vs. legislative activity
- - Trade size vs. historical baseline
- - Disclosure delay (lawmakers have 45 days; longer delays flag as suspicious)
**Why it belongs here:**
- Public dataset: all data sourced from official U.S. Senate and House financial disclosure systems
- - Free to access, no login required
- - Unique AI scoring layer on top of public STOCK Act filings (alongside SEC EDGAR in this category)
- - Covers 800+ lawmakers, 50,000+ disclosed trades
**Sources:** U.S. Senate eFTS system and House of Representatives financial disclosures portal — both 100% public government data.