### PR TITLE
Add Congressional Stock Brain under Government category

### DIFF
--- a/core/Government/US-Congressional-Stock-Brain.yml
+++ b/core/Government/US-Congressional-Stock-Brain.yml
@@ -1,0 +1,24 @@
+---
+title: Congressional Stock Brain
+homepage: https://congressionalstockbrain.com
+category: Government
+description: AI-powered tool ingesting all U.S. STOCK Act disclosures (publicly filed congressional stock trades), converting them into machine-scored trade signals. Scores every lawmaker trade by committee relevance, trade size vs baseline, timing vs legislative activity, and disclosure delay. Free tier available, no login required. Covers 800+ members of Congress.
+keywords: STOCK Act, congressional stock trades, lawmaker trades, government financial disclosure, political trading data
+access_level: public
+language: en
+license: Free (underlying STOCK Act data is public government data)
+publisher:
+- name: Congressional Stock Brain
+  web: https://congressionalstockbrain.com
+  organization:
+  - name: U.S. House Financial Disclosure Portal / U.S. Senate eFTS (data sources)
+    web: https://disclosures.house.gov/FinancialDisclosure
+    issued_time: 2023
+    sources:
+    - name: U.S. House Financial Disclosures Portal
+      access_url: https://disclosures.house.gov/FinancialDisclosure
+      - name: U.S. Senate Electronic Financial Disclosure
+        access_url: https://efts.senate.gov/public/#/search
+        references:
+        - title: STOCK Act
+          reference: https://www.congress.gov/bill/112th-congress/senate-bill/2038

--- a/core/Government/US-Congressional-Stock-Brain.yml
+++ b/core/Government/US-Congressional-Stock-Brain.yml
@@ -8,17 +8,17 @@ access_level: public
 language: en
 license: Free (underlying STOCK Act data is public government data)
 publisher:
-- name: Congressional Stock Brain
-  web: https://congressionalstockbrain.com
-  organization:
-  - name: U.S. House Financial Disclosure Portal / U.S. Senate eFTS (data sources)
-    web: https://disclosures.house.gov/FinancialDisclosure
+  - name: Congressional Stock Brain
+    web: https://congressionalstockbrain.com
+    organization:
+      - name: U.S. House Financial Disclosure Portal / U.S. Senate eFTS (data sources)
+        web: https://disclosures.house.gov/FinancialDisclosure
     issued_time: 2023
     sources:
-    - name: U.S. House Financial Disclosures Portal
-      access_url: https://disclosures.house.gov/FinancialDisclosure
+      - name: U.S. House Financial Disclosures Portal
+        access_url: https://disclosures.house.gov/FinancialDisclosure
       - name: U.S. Senate Electronic Financial Disclosure
         access_url: https://efts.senate.gov/public/#/search
-        references:
-        - title: STOCK Act
-          reference: https://www.congress.gov/bill/112th-congress/senate-bill/2038
+    references:
+      - title: STOCK Act
+        reference: https://www.congress.gov/bill/112th-congress/senate-bill/2038


### PR DESCRIPTION
Adding Congressional Stock Brain to the Government category.

Congressional Stock Brain (https://congressionalstockbrain.com) is a free, AI-powered tool that ingests all U.S. STOCK Act disclosures — the publicly filed congressional stock trades required by law — and converts them into machine-scored trade signals for retail investors.

The underlying data is 100% public government data, sourced directly from:
- U.S. House Financial Disclosures Portal (https://disclosures.house.gov/FinancialDisclosure)
- - U.S. Senate Electronic Financial Trade Submission (https://efts.senate.gov/public/#/search)
The tool scores each filing by: committee assignment relevance, trade size vs. historical baseline, timing relative to legislative activity, and disclosure delay. Free tier available with no login required.