### PR TITLE
Add BenchGecko AI Model Benchmarks under MachineLearning

### DIFF
--- a/core/MachineLearning/BenchGecko-AI-Model-Benchmarks.yml
+++ b/core/MachineLearning/BenchGecko-AI-Model-Benchmarks.yml
@@ -1,0 +1,31 @@
+---
+title: BenchGecko AI Model Benchmarks
+homepage: https://benchgecko.ai
+category: MachineLearning
+description: Benchmark scores, pricing, and capabilities for 414+ AI models across 40 evaluations (MMLU, HumanEval, GSM8K, etc.). Free REST API at benchgecko.ai/api/v1.
+version: 1.0
+keywords: AI benchmarks, LLM, machine learning, model comparison, pricing
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license:
+publisher:
+  - name:
+    web:
+organization:
+  - name: BenchGecko
+    web: https://benchgecko.ai
+issued_time:
+sources:
+  - name: BenchGecko API
+    access_url: https://benchgecko.ai/api/v1
+references:
+  - title:
+    reference:

--- a/core/MachineLearning/BenchGecko-AI-Model-Benchmarks.yml
+++ b/core/MachineLearning/BenchGecko-AI-Model-Benchmarks.yml
@@ -2,7 +2,7 @@
 title: BenchGecko AI Model Benchmarks
 homepage: https://benchgecko.ai
 category: MachineLearning
-description: Benchmark scores, pricing, and capabilities for 414+ AI models across 40 evaluations (MMLU, HumanEval, GSM8K, etc.). Free REST API at benchgecko.ai/api/v1.
+description: Benchmark scores, pricing, and capabilities for 414+ AI models across 40 evaluations (MMLU, HumanEval, GSM8K, etc.). Free REST API documented at benchgecko.ai/api-docs.
 version: 1.0
 keywords: AI benchmarks, LLM, machine learning, model comparison, pricing
 image:
@@ -24,8 +24,12 @@ organization:
     web: https://benchgecko.ai
 issued_time:
 sources:
-  - name: BenchGecko API
-    access_url: https://benchgecko.ai/api/v1
+  - name: BenchGecko API Documentation
+    access_url: https://benchgecko.ai/api-docs
+  - name: Models endpoint
+    access_url: https://benchgecko.ai/api/v1/models
+  - name: Benchmarks endpoint
+    access_url: https://benchgecko.ai/api/v1/benchmarks
 references:
   - title:
     reference:


### PR DESCRIPTION
Adding BenchGecko to the Machine Learning category.

BenchGecko provides structured data on 414+ AI models including benchmark scores across 40 evaluations (MMLU, HumanEval, HellaSwag, ARC, GSM8K, etc.), pricing, context windows, and capabilities. Data is accessible via a free REST API.

Useful for:
- AI research comparing model performance over time
- Cost-benefit analysis of AI providers
- Building evaluation dashboards

Website: https://benchgecko.ai
API: https://benchgecko.ai/api/v1