### PR TITLE
Add Statistics of the World API (Economics)

### DIFF
--- a/core/Economics/Statistics-of-the-World.yml
+++ b/core/Economics/Statistics-of-the-World.yml
@@ -1,0 +1,8 @@
+---
+title: Statistics of the World
+homepage: https://statisticsoftheworld.com/api-docs
+category: Economics
+description: Free API and interactive platform for 440+ economic, demographic, health, and environmental indicators across 218 countries. Data sourced from IMF World Economic Outlook, World Bank WDI, WHO Global Health Observatory, FRED, and United Nations. JSON API with no authentication required for basic use.
+organization:
+  - name: Statistics of the World
+    web: https://statisticsoftheworld.com


### PR DESCRIPTION
Adding [Statistics of the World](https://statisticsoftheworld.com/api-docs) to the Economics category.

**What it provides:**
- 440+ economic, demographic, health, and environmental indicators for 218 countries
- Free JSON API (no authentication required for basic use)
- Data sourced from IMF World Economic Outlook, World Bank WDI, WHO Global Health Observatory, FRED, and United Nations
- Historical data going back to 1960 for many series
- Interactive country comparisons, rankings, and visualizations

API documentation: https://statisticsoftheworld.com/api-docs