### PR TITLE
Add Measured World to SocialSciences

### DIFF
--- a/core/SocialSciences/Measured-World.yml
+++ b/core/SocialSciences/Measured-World.yml
@@ -1,0 +1,25 @@
+---
+title: Measured World
+homepage: https://measuredworld.com
+category: SocialSciences
+description: >
+  Demographic, economic, education, and energy data for up to 237 countries
+  and territories. 147 indicators sourced from UN Population Division, IMF,
+  UNESCO, and EIA, with coverage varying by category.
+version:
+keywords:
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language:
+license:
+publisher:
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
Adds [Measured World](https://measuredworld.com) to the SocialSciences category.

Measured World is a data explorer covering demographic, economic, education, and energy data for up to 237 countries and territories, with 147 indicators sourced from UN Population Division, IMF, UNESCO, and EIA.