### PR TITLE
Add 4 US government data APIs (SOS, building permits, SAM.gov, SEC EDGAR)

### DIFF
--- a/core/Government/SAM-gov-Federal-Contract-Opportunities-API.yml
+++ b/core/Government/SAM-gov-Federal-Contract-Opportunities-API.yml
@@ -1,0 +1,26 @@
+---
+title: SAM.gov Federal Contract Opportunities API
+homepage: https://apify.com/pink_comic/sam-gov-contract-opportunities
+category: Government
+description: API to search federal contract opportunities from SAM.gov (System for Award Management). Returns solicitation details, NAICS codes, set-aside types, deadlines, and contracting office information for government procurement analysis.
+version:
+keywords: SAM.gov, federal contracts, government procurement, solicitations, NAICS, set-aside, government data
+image:
+temporal:
+spatial: United States
+access_level: public
+copyrights:
+accrual_periodicity: real-time
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license:
+publisher:
+  - name:
+    web:
+organization:
+  - name:
+    web:
+issued_time: 2026.03
+sources: []

--- a/core/Government/SEC-EDGAR-Company-Filings-API.yml
+++ b/core/Government/SEC-EDGAR-Company-Filings-API.yml
@@ -1,0 +1,26 @@
+---
+title: SEC EDGAR Company Filings API
+homepage: https://apify.com/pink_comic/sec-edgar-company-filings
+category: Government
+description: API to search SEC EDGAR for company filings including 10-K, 10-Q, 8-K, and other form types. Returns filing date, company name, CIK, form type, and document links for financial research and compliance.
+version:
+keywords: SEC, EDGAR, company filings, 10-K, 10-Q, securities, financial data, government data
+image:
+temporal:
+spatial: United States
+access_level: public
+copyrights:
+accrual_periodicity: real-time
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license:
+publisher:
+  - name: U.S. Securities and Exchange Commission
+    web: https://www.sec.gov
+organization:
+  - name:
+    web:
+issued_time: 2026.03
+sources: []

--- a/core/Government/US-Building-Permits-Construction-Data-API.yml
+++ b/core/Government/US-Building-Permits-Construction-Data-API.yml
@@ -1,0 +1,26 @@
+---
+title: US Building Permits and Construction Data API
+homepage: https://apify.com/pink_comic/building-permits-construction-leads
+category: Government
+description: API providing building permit records from 47 US cities via Socrata open data portals. Returns permit type, status, contractor, address, valuation, and dates for construction market analysis and contractor lead generation.
+version:
+keywords: building permits, construction, government data, open data, Socrata, contractor, real estate
+image:
+temporal:
+spatial: United States (47 cities)
+access_level: public
+copyrights:
+accrual_periodicity: real-time
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license:
+publisher:
+  - name:
+    web:
+organization:
+  - name:
+    web:
+issued_time: 2026.03
+sources: []

--- a/core/Government/US-Secretary-of-State-Business-Entity-Search-API.yml
+++ b/core/Government/US-Secretary-of-State-Business-Entity-Search-API.yml
@@ -1,0 +1,26 @@
+---
+title: US Secretary of State Business Entity Search API
+homepage: https://apify.com/pink_comic/us-business-entity-search
+category: Government
+description: API to search Secretary of State business entity registrations across 17 US states. Returns entity name, status, filing date, type, state, and registration details from official state portals for KYC, compliance, and sales prospecting.
+version:
+keywords: secretary of state, business entity, LLC, corporation, KYC, compliance, business registration, government data
+image:
+temporal:
+spatial: United States (17 states)
+access_level: public
+copyrights:
+accrual_periodicity: real-time
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license:
+publisher:
+  - name:
+    web:
+organization:
+  - name:
+    web:
+issued_time: 2026.02
+sources: []


### PR DESCRIPTION
Adding 4 US government public data APIs to the Government category:

1. **US Secretary of State Business Entity Search** - Search business entity registrations across 17 US states for KYC/compliance
2. **US Building Permits and Construction Data** - Building permit records from 47 US cities via Socrata open data portals
3. **SAM.gov Federal Contract Opportunities** - Federal procurement solicitations from SAM.gov
4. **SEC EDGAR Company Filings** - SEC EDGAR filing search (10-K, 10-Q, 8-K, etc.)

All provide API access to publicly available US government data.