### PR TITLE
Add Webb-Database under Finance

### DIFF
--- a/core/Finance/Webb-Database.yml
+++ b/core/Finance/Webb-Database.yml
@@ -1,0 +1,21 @@
+---
+title: Webb Database
+homepage: https://webb-database.com
+category: Finance
+description: Aggregates and structures public financial data from HKEX, the SFC, the Hong Kong Law Society, UK Companies House, and other official sources. It provides organized, searchable datasets on listed companies, corporate entities, and related financial information, many in machine-readable formats.
+version: 1.0
+keywords:
+image:
+temporal:
+spatial:
+access_level:
+copyrights:
+accrual_periodicity:
+specification:
+data_dictionary:
+language:
+license:
+publisher:
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
---
title: Webb Database
homepage: https://webb-database.com
category: Finance
description: Aggregates and structures public financial data from HKEX, the SFC, the Hong Kong Law Society, UK Companies House, and other official sources. It provides organized, searchable datasets on listed companies, corporate entities, and related financial information, many in machine-readable formats.
version: 1.0
keywords:
image:
temporal:
spatial:
access_level:
copyrights:
accrual_periodicity:
specification:
data_dictionary:
language:
license:
publisher:
organization:
issued_time:
sources: []