### PR TITLE
Add Crime Brasil — Brazilian crime data, geocoded by neighborhood (Government)

### DIFF
--- a/core/Government/Crime-Brasil-Brazil.yml
+++ b/core/Government/Crime-Brasil-Brazil.yml
@@ -1,0 +1,39 @@
+---
+title: Crime Brasil
+homepage: https://crimebrasil.com.br
+category: Government
+description: Open-data platform consolidating and geocoding criminal incidents from Brazilian state police (SSP) sources. Neighborhood-level coverage in Rio Grande do Sul (~3M incidents, 2022-2025, 99.99% geocoded to 79,024 neighborhoods across 497 municipalities), municipality-level data for Minas Gerais and Rio de Janeiro, national federal-highway accidents (PRF DATATRAN), and nationwide interpersonal-violence data (DATASUS SINAN). Free REST API and CSV/Parquet exports.
+version: 2026.04
+keywords: crime, public safety, police, Brazil, geocoding, neighborhood, municipality, open government data, SSP, PRF, DATASUS, feminicide, violence
+image:
+temporal: 2009-2025
+spatial: Brazil (RS, MG, RJ, all states via PRF/DATASUS)
+access_level: public
+copyrights:
+accrual_periodicity: daily
+specification: JSON REST API + CSV/Parquet downloads
+data_quality: true
+data_dictionary: https://crimebrasil.com.br/api/data-sources
+language: pt-BR
+license: CC BY 4.0
+publisher:
+  - name: Crime Brasil
+    web: https://crimebrasil.com.br
+organization:
+  - name: Crime Brasil
+    web: https://crimebrasil.com.br/imprensa
+issued_time: 2025.06
+sources:
+  - name: SSP Rio Grande do Sul
+    access_url: https://www.ssp.rs.gov.br/dados-abertos
+  - name: ISP Rio de Janeiro
+    access_url: https://www.ispdados.rj.gov.br/
+  - name: SEJUSP Minas Gerais
+    access_url: https://www.seguranca.mg.gov.br/
+  - name: PRF DATATRAN
+    access_url: https://www.gov.br/prf/pt-br/acesso-a-informacao/dados-abertos
+  - name: DATASUS SINAN
+    access_url: https://datasus.saude.gov.br/
+references:
+  - title: Crime Brasil — Imprensa
+    reference: https://crimebrasil.com.br/imprensa


### PR DESCRIPTION
## What

Adds **Crime Brasil** to `core/Government/` as `Crime-Brasil-Brazil.yml`.

## Why

Crime Brasil (https://crimebrasil.com.br) fills a clear gap in open Brazilian crime data — state police (SSP) sources publish fragmented PDFs and inconsistent CSVs without geocoding. This project consolidates and geocodes them:

- **Rio Grande do Sul**: ~3M incidents (2022–2025), 497 municipalities, 79,024 neighborhoods, 99.99% geocoded
- **Minas Gerais**: ~965K violent incidents (municipality-level)
- **Rio de Janeiro**: ~37K ISP/CISP records (municipality-level)
- **National — PRF DATATRAN**: federal-highway accidents, 2020–2026, all 27 states
- **National — DATASUS SINAN**: interpersonal violence, 2009–2024

## Access

- **Homepage**: https://crimebrasil.com.br
- **REST API**: https://crimebrasil.com.br/api/data-sources
- **Press kit / citation**: https://crimebrasil.com.br/imprensa
- **License**: CC BY 4.0
- **Update cadence**: daily

## Disclosure

I'm the maintainer of Crime Brasil. Submission discloses self-promotion per the CONTRIBUTING guidelines.

## Checklist

- [x] Title, homepage, and category fields set
- [x] File placed under correct category folder (Government)
- [x] License specified (CC BY 4.0)
- [x] Sources documented
- [x] Temporal + spatial coverage declared