### PR TITLE
Fix: Update broken link for Heart Rate Time Series MIT dataset.

### DIFF
--- a/core/TimeSeries/Heart-Rate-Time-Series-from-MIT.yml
+++ b/core/TimeSeries/Heart-Rate-Time-Series-from-MIT.yml
@@ -1,6 +1,6 @@
 ---
 title: Heart Rate Time Series from MIT
-homepage: http://ecg.mit.edu/time-series/
+homepage: "https://physionet.org/content/mitdb/1.0.0/"
 category: TimeSeries
 description:
 version:

--- a/core/TimeSeries/Heart-Rate-Time-Series-from-MIT.yml
+++ b/core/TimeSeries/Heart-Rate-Time-Series-from-MIT.yml
@@ -1,6 +1,6 @@
 ---
 title: Heart Rate Time Series from MIT
-homepage: "https://physionet.org/content/mitdb/1.0.0/"
+homepage: https://physionet.org/content/mitdb/1.0.0/
 category: TimeSeries
 description:
 version:


### PR DESCRIPTION
Description
Fixed a broken link for the Heart Rate Time Series from MIT dataset.

Old URL: http://ecg.mit.edu/time-series/ (Timing out/Dead)

New URL: https://physionet.org/content/mitdb/1.0.0/ (Official PhysioNet archive)