### PR TITLE
Fix: Update legacy USDA Nutrient Database to FoodData Central

### DIFF
--- a/core/Agriculture/U.S.-Department-of-Agricultures-Nutrient-Database.yml
+++ b/core/Agriculture/U.S.-Department-of-Agricultures-Nutrient-Database.yml
@@ -1,8 +1,11 @@
 ---
-title: U.S. Department of Agriculture's Nutrient Database
-homepage: https://fdc.nal.usda.gov/download-datasets
-category: Agriculture
-description: USDA National Nutrient Database for Standard Reference (renamed in 2019 to FoodData Central)
+title: "USDA FoodData Central"
+homepage: "https://fdc.nal.usda.gov/download-datasets"
+category: "Agriculture"
+description: >
+  The primary source for food composition data from the USDA, providing 
+  comprehensive nutrient profiles. It is the modern successor to the 
+  National Nutrient Database for Standard Reference. 
 version:
 keywords:
 image:
@@ -12,11 +15,11 @@ access_level:
 copyrights:
 accrual_periodicity:
 specification:
-data_quality: false
+data_quality: true
 data_dictionary:
 language: English
 license:
 publisher:
-organization:
+organization: "U.S. Department of Agriculture (USDA)"
 issued_time:
 sources: []

--- a/core/TimeSeries/Heart-Rate-Time-Series-from-MIT.yml
+++ b/core/TimeSeries/Heart-Rate-Time-Series-from-MIT.yml
@@ -1,6 +1,6 @@
 ---
 title: Heart Rate Time Series from MIT
-homepage: http://ecg.mit.edu/time-series/
+homepage: "https://physionet.org/content/mitdb/1.0.0/"
 category: TimeSeries
 description:
 version:


### PR DESCRIPTION
Description
Updated the metadata for the USDA Agriculture dataset.

Title: Updated from "Nutrient Database" to the official current name "FoodData Central".

Homepage: Updated to the direct download portal.

Description: Refactored to reflect that this is the modern successor to the legacy database.