### PR TITLE
Fix: Update broken CIMA dataset link to kaggle mirror

### DIFF
--- a/core/Biology/CIMA.yml
+++ b/core/Biology/CIMA.yml
@@ -1,6 +1,6 @@
 ---
-title: CIMA
-homepage: https://cmp.felk.cvut.cz/~borovji3/?page=dataset
+title: "CIMA: Histological Microscopy Tissue Slices"
+homepage: "https://www.kaggle.com/datasets/jirkaborovec/histology-cima-dataset"
 category: Biology
 description: CIMA dataset includes images of 2D histological microscopy tissue slices.
 version:


### PR DESCRIPTION
## Fix broken link

- Dataset: CIMA - 2D histological microscopy tissue slices
- Old URL: http://cmp.felk.cvut.cz/~borovji3/?page=dataset (404 Dead)
- New URL: https://www.kaggle.com/datasets/jirkaborovec/histology-cima-dataset
- Reason: Original CTU hosting is down. GitHub mirror is archived. 
  Kaggle is the only currently accessible public source, uploaded 
  by the original author (jirkaborovec).