### PR TITLE
Fix: Update broken link for Cell Image Library

### DIFF
--- a/core/Biology/Cell-Image-Library.yml
+++ b/core/Biology/Cell-Image-Library.yml
@@ -1,8 +1,8 @@
 ---
 title: Cell Image Library
-homepage: http://www.cellimagelibrary.org/home
+homepage: "https://www.cellimagelibrary.org/home"
 category: Biology
-description: This library is a public and easily accessible resource database of images, videos, and animations of cells, capturing a wide diversity of organisms, cell types, and cellular processes. The purpose of this database is to advance research on cellular activity, with the ultimate goal of improving human health.
+description: 
 version:
 keywords:
 image:


### PR DESCRIPTION
## Fix broken link

- Dataset: Cell Image Library
- Old URL: http://www.cellimagelibrary.org (no redirect)
- New URL: https://www.cellimagelibrary.org/home
- Reason: Root URL doesn't redirect, updated to correct 
  working homepage with HTTPS