### PR TITLE
Add Voidly Censorship Data under ComputerNetworks

### DIFF
--- a/core/ComputerNetworks/Voidly-Censorship-Data.yml
+++ b/core/ComputerNetworks/Voidly-Censorship-Data.yml
@@ -1,0 +1,33 @@
+---
+title: 'Voidly Censorship Data: Global internet censorship measurements'
+homepage: https://huggingface.co/datasets/emperor-mew/global-censorship-index
+category: ComputerNetworks
+description: Live and historical internet censorship measurements aggregated from OONI and partner probe networks. Covers 19.6M data points across 126 countries (live JSON) plus a 1.6M-row 10-year historical archive in Parquet. Includes per-country block rates, per-domain reachability, ISP/ASN signals, and incident-level labels suitable for ML training and research.
+version:
+keywords: internet censorship, ooni, network interference, dns blocking, http blocking, tls, web connectivity, blocking detection, freedom of expression
+image:
+temporal: 2016-2026
+spatial: 126 countries
+access_level: public
+copyrights:
+accrual_periodicity: every 6 hours
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license: CC BY 4.0
+publisher:
+  - name: Voidly
+    web: https://voidly.ai
+organization:
+  - name: Voidly
+    web: https://voidly.ai
+issued_time: 2026
+sources:
+  - name: Live censorship index (JSON)
+    access_url: https://huggingface.co/datasets/emperor-mew/global-censorship-index
+  - name: 10-year historical archive (Parquet)
+    access_url: https://huggingface.co/datasets/emperor-mew/ooni-censorship-historical
+references:
+  - title: OONI (upstream raw measurements)
+    reference: https://ooni.torproject.org/data/


### PR DESCRIPTION
## What

Adds **Voidly Censorship Data** to `core/ComputerNetworks/`.

## Why it fits

- Sits alongside the existing OONI entry in the same folder — Voidly builds on OONI's raw measurements and re-releases them as analysis-ready data
- Meets the "high quality" criteria in `CONTRIBUTING.md`:
  - Contributes valuable knowledge for internet-freedom / network-measurement research
  - Downloadable directly from Hugging Face — no login or purchase required
  - CC BY 4.0 licensed
  - No ads, no promo copy

## Details

- **Live dataset:** `emperor-mew/global-censorship-index` — 19.6M data points across 126 countries, JSON
- **Historical archive:** `emperor-mew/ooni-censorship-historical` — 1.6M rows over 10 years, Parquet
- Refreshed every 6 hours from OONI + partner probe networks
- Useful for ML training (incident classification, shutdown forecasting), journalism, and comparative internet-freedom research

## Validation

`title`, `homepage`, and `category` are set; `category` matches the folder name (`ComputerNetworks`).