### PR TITLE
Add USDA NASS County Crop Yields under Agriculture

### DIFF
--- a/core/Agriculture/USDA-NASS-County-Crop-Yields.yml
+++ b/core/Agriculture/USDA-NASS-County-Crop-Yields.yml
@@ -1,0 +1,32 @@
+---
+title: USDA NASS County Crop Yields
+homepage: https://productofamerica.github.io/usda-county-yields/
+category: Agriculture
+description: "Free static JSON API serving USDA NASS county-level annual yields for corn, soybeans, and wheat in the United States. Refreshed weekly from the NASS bulk file. Sharded by (state, county, crop) so a single point lookup downloads 2-22 KB instead of a multi-megabyte state shard. The producer pre-marks the canonical series per crop so consumer code is a one-liner. No API key, no rate limits, no auth. Hosted on the jsDelivr CDN. JSON Schema 2020-12 contract published alongside the data."
+version: 1.0
+keywords: USDA, NASS, agriculture, crop yields, corn, soybeans, wheat, county-level, public domain, JSON, API, jsDelivr, agricultural data, ag-tech
+temporal: 1910-present
+spatial: United States, county-level (3000+ counties, 42 states)
+access_level: public
+copyrights:
+accrual_periodicity: weekly
+specification: https://cdn.jsdelivr.net/gh/ProductOfAmerica/usda-county-yields@main/data/_schema/leaf.json
+data_quality: true
+data_dictionary:
+language: en
+license: Creative Commons Zero (CC0, public domain) for data; MIT for cache code
+publisher:
+  - name: ProductOfAmerica
+    web: https://github.com/ProductOfAmerica/usda-county-yields
+organization:
+  - name: USDA National Agricultural Statistics Service
+    web: https://www.nass.usda.gov/
+issued_time: 2026.04
+sources:
+  - name: USDA NASS Quick Stats bulk file
+    access_url: https://www.nass.usda.gov/datasets/
+references:
+  - title: Repository
+    reference: https://github.com/ProductOfAmerica/usda-county-yields
+  - title: JSON Schema (point leaf)
+    reference: https://cdn.jsdelivr.net/gh/ProductOfAmerica/usda-county-yields@main/data/_schema/leaf.json


### PR DESCRIPTION
Adds USDA NASS County Crop Yields to `core/Agriculture/`.

**What it is:**
- Free static JSON API serving USDA NASS county-level corn, soybean, and wheat yield data (annual, county-level, SURVEY rows).
- Refreshed weekly from the NASS bulk file `qs.crops_*.txt.gz` via a public GitHub Actions cron.
- Hosted on the jsDelivr CDN: per-county point lookups in 2-22 KB. No API key, no rate limits, no auth.
- USDA NASS data is U.S. public domain; the cache code is MIT.
- JSON Schema 2020-12 contract published alongside the data at `data/_schema/leaf.json`.

**Why it qualifies:**
- Public, downloadable directly without login or purchase.
- Adds value vs. the existing NASS Quick Stats API by removing the API-key + rate-limit barrier and providing a CDN-fronted point-lookup shape suitable for ML pipelines and notebooks.
- No advertising, spam, or reputation promotion.

**Where:**
- Homepage (landing page with full docs + Schema.org Dataset JSON-LD): https://productofamerica.github.io/usda-county-yields/
- Repository: https://github.com/ProductOfAmerica/usda-county-yields

YAML validates locally with the required `title`, `homepage`, and `category` fields.