### PR TITLE
``` Add PottyDirectory: US portable-restroom open dataset (Government) ```

### DIFF
--- a/core/Government/PottyDirectory-USA.yml
+++ b/core/Government/PottyDirectory-USA.yml
@@ -1,5 +1,3 @@
-```yaml
----
 title: PottyDirectory — US Portable Restroom & Public Restroom Open Data
 homepage: https://pottydirectory.com/data
 category: Government
@@ -22,5 +20,3 @@ sources:
     web: https://pottydirectory.com/llms.txt
   - name: Methodology + sourcing
     web: https://pottydirectory.com/methodology
----
-```

--- a/core/Government/PottyDirectory-USA.yml
+++ b/core/Government/PottyDirectory-USA.yml
@@ -1,0 +1,26 @@
+```yaml
+---
+title: PottyDirectory — US Portable Restroom & Public Restroom Open Data
+homepage: https://pottydirectory.com/data
+category: Government
+description: Open dataset of 3,649 US portable-restroom rental vendors across all 50 states + DC and 2,424 cities, plus a public-restroom finder. Free to access and cite. Includes per-vendor service flags (ADA-accessible, luxury trailer, hand-wash station, serves construction, serves events), national pricing reference ranges, and transparent methodology. Schema.org Dataset markup for machine-readable consumption.
+keywords:
+  - sanitation
+  - portable toilet
+  - public restroom
+  - civic infrastructure
+  - construction
+spatial: United States
+access_level: public
+license: Free to access; attribution requested for redistribution
+publisher: Lighthouse 27 LLC
+data_quality: true
+sources:
+  - name: PottyDirectory canonical dataset page
+    web: https://pottydirectory.com/data
+  - name: Machine-readable summary (llms.txt)
+    web: https://pottydirectory.com/llms.txt
+  - name: Methodology + sourcing
+    web: https://pottydirectory.com/methodology
+---
+```


### PR DESCRIPTION
```
Adding PottyDirectory.com as a new entry under Government.

**What it is:** Open dataset of 3,649 US portable-restroom rental vendors across all 50 states + DC and 2,424 cities, with a public-restroom finder. Free to access, no registration. Schema.org Dataset markup for machine-readable consumption.

**Why it fits the criteria:**
- Directly downloadable / accessible without login (sitemap-index.xml lists every page; /llms.txt provides a machine-readable summary)
- No advertisements / no spam
- Documents a domain not well-tracked by government sources (US Census NAICS 562991 covers waste management but not the portable-restroom rental industry specifically)
- Transparent methodology page: https://pottydirectory.com/methodology

**Disclosure:** I am the operator of PottyDirectory (Lighthouse 27 LLC). Submitting this entry myself; happy to defer to maintainer judgment on the right category or wording.

Closes — N/A
```