### PR TITLE
Add iNaturalist and Open Food Facts to open datasets

### DIFF
--- a/core/Agriculture/OpenFoodFacts.yml
+++ b/core/Agriculture/OpenFoodFacts.yml
@@ -1,0 +1,22 @@
+---
+title: Open Food Facts
+homepage: https://world.openfoodfacts.org/
+category: Agriculture
+description: Crowdsourced food composition database covering 2.5M+ products from 170+ countries. Includes ingredients, nutrition facts, labels, and additives. ODbL licensed with REST and MongoDB dump exports.
+version:
+keywords: food, nutrition, products, ingredients, labels
+image:
+temporal:
+spatial: global
+access_level: public
+copyrights: ODbL
+accrual_periodicity: daily
+specification: https://world.openfoodfacts.org/data
+data_quality: true
+data_dictionary: https://world.openfoodfacts.org/data/data-fields.txt
+language: multilingual
+license: ODbL
+publisher: Open Food Facts
+organization: Open Food Facts
+issued_time:
+sources: []

--- a/core/Biology/iNaturalist.yml
+++ b/core/Biology/iNaturalist.yml
@@ -1,0 +1,22 @@
+---
+title: iNaturalist
+homepage: https://www.inaturalist.org/
+category: Biology
+description: Community-maintained species observation database with 180M+ observations across 370K+ taxa. Includes location, date, species ID, and photos. CC0/CC-BY licensed with open API.
+version:
+keywords: biodiversity, species, ecology, citizen-science, observations
+image:
+temporal:
+spatial: global
+access_level: public
+copyrights: CC0/CC-BY
+accrual_periodicity: daily
+specification: https://api.inaturalist.org/v1/docs/
+data_quality: true
+data_dictionary:
+language: en
+license: CC0/CC-BY
+publisher: iNaturalist
+organization: California Academy of Sciences / National Geographic Society
+issued_time:
+sources: []


### PR DESCRIPTION
## What this adds

Two widely-used open datasets not yet in the index:

- **iNaturalist** (`core/Biology/iNaturalist.yml`) — community species observation database, 180M+ observations across 370K+ taxa, CC0/CC-BY licensed, daily-updated REST API
- **Open Food Facts** (`core/Agriculture/OpenFoodFacts.yml`) — crowdsourced food composition database, 2.5M+ products from 170+ countries, ODbL licensed, REST and MongoDB dump exports

Both are widely cited in academic ML and data science literature, have stable APIs, and are actively maintained. Format follows existing entries.