### PR TITLE
Add trove healthcare dataset (HCRIS + 990 Schedule H + FDA approvals)

### DIFF
--- a/core/Healthcare/Trove.yml
+++ b/core/Healthcare/Trove.yml
@@ -1,0 +1,32 @@
+title: trove
+homepage: https://troveproject.com
+category: Healthcare
+description: Reference tools for two underused public-domain U.S. healthcare datasets. (1) FDA novel drug
+approvals 2021–2024 (218 drugs across CDER NMEs/BLAs and CBER cell/gene therapies) with deep links to the FDA
+approval package — medical, statistical, pharmacology, and chemistry reviews. (2) U.S. nonprofit hospital
+reporting — CMS Medicare Cost Reports (HCRIS Worksheet S-10) and IRS Form 990 Schedule H side-by-side for
+1,295 nonprofit hospital systems, with home-county CDC Social Vulnerability Index context. Published as
+Parquet + JSON + CSV bundles, plus two Claude Code skills for natural-language query.
+version:
+keywords: FDA, drug approvals, NME, NDA, BLA, CMS, HCRIS, Medicare Cost Report, IRS, 990, Schedule H,
+nonprofit hospitals, charity care, community benefit, social vulnerability index, Claude Code skills
+image:
+temporal: 2021-2024 (FDA), TY2022/FY2023 (hospitals)
+spatial: US
+access_level: Public
+copyrights:
+accrual_periodicity: as released
+specification:
+data_quality: true
+data_dictionary: https://github.com/cbetz/trove
+language: English
+license: https://opensource.org/licenses/MIT
+publisher: Chris Betz / trove
+organization: trove
+issued_time: 2026-05
+sources:
+  - https://www.fda.gov/drugs/development-approval-process-drugs/novel-drug-approvals-fda
+  - https://www.fda.gov/vaccines-blood-biologics/cellular-gene-therapy-products/approved-cellular-and-gene-the
+rapy-products
+  - https://www.cms.gov/data-research/statistics-trends-and-reports/cost-reports
+  - https://www.irs.gov/charities-non-profits/form-990-series-downloads

--- a/core/Healthcare/Trove.yml
+++ b/core/Healthcare/Trove.yml
@@ -1,15 +1,9 @@
 title: trove
 homepage: https://troveproject.com
 category: Healthcare
-description: Reference tools for two underused public-domain U.S. healthcare datasets. (1) FDA novel drug
-approvals 2021–2024 (218 drugs across CDER NMEs/BLAs and CBER cell/gene therapies) with deep links to the FDA
-approval package — medical, statistical, pharmacology, and chemistry reviews. (2) U.S. nonprofit hospital
-reporting — CMS Medicare Cost Reports (HCRIS Worksheet S-10) and IRS Form 990 Schedule H side-by-side for
-1,295 nonprofit hospital systems, with home-county CDC Social Vulnerability Index context. Published as
-Parquet + JSON + CSV bundles, plus two Claude Code skills for natural-language query.
+description: "Reference tools for two underused public-domain U.S. healthcare datasets. (1) FDA novel drug approvals 2021–2024 (218 drugs across CDER NMEs/BLAs and CBER cell/gene therapies) with deep links to the FDA approval package — medical, statistical, pharmacology, and chemistry reviews. (2) U.S. nonprofit hospital reporting — CMS Medicare Cost Reports (HCRIS Worksheet S-10) and IRS Form 990 Schedule H side-by-side for 1,295 nonprofit hospital systems, with home-county CDC Social Vulnerability Index context. Published as Parquet + JSON + CSV bundles, plus two Claude Code skills for natural-language query."
 version:
-keywords: FDA, drug approvals, NME, NDA, BLA, CMS, HCRIS, Medicare Cost Report, IRS, 990, Schedule H,
-nonprofit hospitals, charity care, community benefit, social vulnerability index, Claude Code skills
+keywords: "FDA, drug approvals, NME, NDA, BLA, CMS, HCRIS, Medicare Cost Report, IRS, 990, Schedule H, nonprofit hospitals, charity care, community benefit, social vulnerability index, Claude Code skills"
 image:
 temporal: 2021-2024 (FDA), TY2022/FY2023 (hospitals)
 spatial: US
@@ -26,7 +20,6 @@ organization: trove
 issued_time: 2026-05
 sources:
   - https://www.fda.gov/drugs/development-approval-process-drugs/novel-drug-approvals-fda
-  - https://www.fda.gov/vaccines-blood-biologics/cellular-gene-therapy-products/approved-cellular-and-gene-the
-rapy-products
+  - https://www.fda.gov/vaccines-blood-biologics/cellular-gene-therapy-products/approved-cellular-and-gene-therapy-products
   - https://www.cms.gov/data-research/statistics-trends-and-reports/cost-reports
   - https://www.irs.gov/charities-non-profits/form-990-series-downloads


### PR DESCRIPTION
Adds a new Healthcare entry: **trove** — reference tools and Parquet/JSON bundles for two widely-cited but
rarely-usable U.S. healthcare datasets:

1. **FDA novel drug approvals (2021–2024)** — 218 drugs covering both regulatory centers (CDER NMEs/BLAs +
CBER cell and gene therapies), each with sponsor, application number, approval date, indication, and a direct
link to the full FDA approval package (medical / statistical / pharmacology / chemistry reviews).
2. **U.S. nonprofit hospital reporting** — CMS Worksheet S-10 (charity care) and IRS 990 Schedule H Part I 7a
(financial assistance at cost) joined at the EIN level for 1,295 nonprofit hospital systems, with home-county
CDC Social Vulnerability Index context.

- Live site: https://troveproject.com
- Source: https://github.com/cbetz/trove (MIT-licensed parsers, build scripts, raw artifacts)
- Direct Parquet downloads: https://troveproject.com/data/fda_approvals_nme_recent.parquet,
https://troveproject.com/data/community_benefit_gap_2022.parquet
- Underlying data is U.S. government work, public domain.