### PR TITLE
Add US Fragrance Trends 2026 (50-state Google Trends, CC BY 4.0)

### DIFF
--- a/core/SocialSciences/US-Fragrance-Trends-2026.yml
+++ b/core/SocialSciences/US-Fragrance-Trends-2026.yml
@@ -1,0 +1,24 @@
+---
+title: US Fragrance Trends 2026 — Most-Searched Fragrance by US State
+homepage: https://github.com/ahmad-khan-97/us-fragrance-trends-2026
+category: SocialSciences
+description: >-
+  A 12-month Google Trends analysis (May 2025 – April 2026) of US consumer interest in 30 top
+  designer, niche, and celebrity fragrances, broken down by state. Each row identifies the
+  single fragrance with the highest average Google search interest in each US state plus DC.
+  Open consumer-research dataset of fragrance preference geography.
+keywords: consumer-research,google-trends,fragrance,perfume,cologne,us-states,beauty,retail,time-series
+spatial: United States (50 states + DC)
+temporal: May 2025 - April 2026 (12-month window)
+access_level: public
+license: CC BY 4.0
+language: en
+publisher:
+  - name: PerfumeM
+    web: https://perfumem.com
+organization:
+  - name: PerfumeM
+    web: https://perfumem.com
+sources:
+  - name: Google Trends (public web)
+    access_url: https://trends.google.com


### PR DESCRIPTION
### Adding: US Fragrance Trends 2026

A 12-month Google Trends consumer-research dataset of the most-searched fragrance in each US state (50 states + DC), spanning May 2025 - April 2026. 30 top designer/niche/celebrity fragrances were tracked; the dataset records the fragrance with the highest average Google search interest per state.

**Why this fits SocialSciences / awesome-public-datasets:**
- Open data (CC BY 4.0)
- US-wide geographic coverage
- Directly downloadable (CSV/JSON in the repo root)
- Captures regional consumer-behavior signals across an industry that's traditionally opaque
- Sourced from a public, replicable Google Trends methodology

**Repo:** https://github.com/ahmad-khan-97/us-fragrance-trends-2026
**License:** CC BY 4.0
**Format:** CSV + README with methodology

Happy to address any feedback on the YAML format / metadata fields.
