### PR TITLE
Adds Crusader Atlas (https://crusaderatlas.com/) to the GIS section.

### DIFF
--- a/Crusader-Atlas.yml
+++ b/Crusader-Atlas.yml
@@ -1,0 +1,10 @@
+---
+title: Crusader Atlas
+homepage: https://crusaderatlas.com/
+category: GIS
+description: 170 catalogued Crusader-era sites (castles, churches, fortified towns, battles, sieges) plus 31 lordship polygons across the Latin East, 1099-1291, with WGS84 coordinates, GeoJSON geometries, photographs, and source-backed historical notes. Crusader-period analog to Pleiades.
+keywords: crusades, history, archaeology, fortresses, kingdom-of-jerusalem, gis, gazetteer, middle-east, geojson, historical-atlas
+access_level: public
+license: CC-BY-4.0
+language: en
+issued_time: 2026

--- a/Crusader-Atlas.yml
+++ b/Crusader-Atlas.yml
@@ -2,9 +2,32 @@
 title: Crusader Atlas
 homepage: https://crusaderatlas.com/
 category: GIS
-description: 170 catalogued Crusader-era sites (castles, churches, fortified towns, battles, sieges) plus 31 lordship polygons across the Latin East, 1099-1291, with WGS84 coordinates, GeoJSON geometries, photographs, and source-backed historical notes. Crusader-period analog to Pleiades.
+description: Hand-curated geographic gazetteer of 170 Crusader-era sites (castles, churches, fortified towns, battles, sieges) plus 31 lordship polygons across the Latin East, 1099-1291, with WGS84 coordinates, GeoJSON geometries, photographs, and source-backed historical notes. Crusader-period analog to Pleiades.
+version: 1.0
 keywords: crusades, history, archaeology, fortresses, kingdom-of-jerusalem, gis, gazetteer, middle-east, geojson, historical-atlas
+image: https://crusaderatlas.com/og-image.png
+temporal: 1099-1291
+spatial: Latin East (Israel, Palestine, Jordan, Lebanon, Syria, southern Turkey)
 access_level: public
-license: CC-BY-4.0
+copyrights:
+accrual_periodicity: irregular
+specification: HTML + Leaflet + inline JSON; landing pages with Place/Person/Article JSON-LD; GeoJSON for lordship polygons and pilgrim roads
+data_quality: false
+data_dictionary:
 language: en
-issued_time: 2026
+license: CC-BY-4.0
+publisher:
+  - name: Crusader Atlas
+    web: https://crusaderatlas.com/
+organization:
+  - name:
+    web:
+issued_time: 2026.04
+sources:
+  - name: Denys Pringle, "The Churches of the Crusader Kingdom of Jerusalem" (4 vols., Cambridge UP) and "Secular Buildings in the Crusader Kingdom of Jerusalem"
+    access_url:
+  - name: Wikipedia (English + Hebrew + Arabic)
+    access_url: https://en.wikipedia.org/wiki/Crusader_states
+references:
+  - title:
+    reference:

--- a/Crusader-Atlas.yml
+++ b/Crusader-Atlas.yml
@@ -2,12 +2,25 @@
 title: Crusader Atlas
 homepage: https://crusaderatlas.com/
 category: GIS
+version: ""
+image: ""
 description: Hand-curated geographic gazetteer of 170 Crusader-era sites (castles, churches, fortified towns, battles, sieges) plus 31 lordship polygons across the Latin East, 1099-1291, with WGS84 coordinates, GeoJSON geometries, photographs, and source-backed historical notes. Crusader-period analog to Pleiades.
 version: 1.0
 keywords: crusades, history, archaeology, fortresses, kingdom-of-jerusalem, gis, gazetteer, middle-east, geojson, historical-atlas
 image: https://crusaderatlas.com/og-image.png
 temporal: 1099-1291
 spatial: Latin East (Israel, Palestine, Jordan, Lebanon, Syria, southern Turkey)
+temporal:
+  start: 1099
+  end: 1291
+spatial:
+  bbox: ""
+copyrights:
+  license: CC-BY-4.0
+publisher: ""
+organization: ""
+sources: []
+references: []
 access_level: public
 copyrights:
 accrual_periodicity: irregular


### PR DESCRIPTION
Adds Crusader Atlas (https://crusaderatlas.com/) to the GIS section.

Hand-curated geographic gazetteer of 170 Crusader-era sites in the Latin East (1099-1291) — fortresses, churches, fortified towns, battles, sieges — plus 31 lordship polygons and pilgrim-road LineStrings. WGS84 coordinates throughout, GeoJSON for polygon data, photographs of current survival status, source-backed historical notes drawing on Pringle's "Secular Buildings" catalogue and current archaeological reporting.

Crusader-period analog to Pleiades (already listed). Open access, no signup, no ads. CC BY 4.0.

Source code and build pipeline:
https://github.com/mintycake420/crusaderatlas
