### PR TITLE
Add Zip-Codes API to GIS

### DIFF
--- a/core/GIS/Zip-Codes-API.yml
+++ b/core/GIS/Zip-Codes-API.yml
@@ -1,0 +1,34 @@
+ ---
+  title: Zip-Codes API
+  homepage: https://www.zip-codes.com/api/
+  category: GIS
+  description: REST API delivering US ZIP, ZIP+4, and Canadian postal code data — address standardization, radius search
+   (centroid and spatial polygon), point-to-point distance, Census ACS demographics (2011–2024), and boundary lookups
+  (Census tracts, congressional districts, school districts) with computed intersection percentages.
+  version:
+  keywords:
+    - zip-code
+    - postal-code
+    - geocoding
+    - address-validation
+    - census
+    - demographics
+    - acs
+    - boundaries
+    - canada
+    - usa
+  image:
+  temporal: 2011–2024 (Census ACS); current (postal data, monthly)
+  spatial: United States, Canada
+  access_level: API key (free tier — 2,500 lookups/day, no credit card)
+  copyrights:
+  accrual_periodicity: Monthly (postal); annual (Census ACS); quarterly (boundaries)
+  specification: https://api.zip-codes.com/v2/openapi.json
+  data_quality: false
+  data_dictionary: https://api.zip-codes.com/docs
+  language: en
+  license:
+  publisher: Zip-Codes.com
+  organization: Zip-Codes.com
+  issued_time: 2026-03-12
+  sources: []


### PR DESCRIPTION
  Adds Zip-Codes API to core/GIS/.

  REST API delivering postal-code-keyed spatial and demographic data:

  - US ZIP, ZIP+4, and Canadian postal codes (single unified endpoint)
  - Address standardization and validation
  - Radius search — both centroid haversine and true spatial polygon intersection
  - Point-to-point distance
  - Census ACS demographics, 2011–2024 (14 years, 542 fields per ZIP)
  - Boundary intersections with computed overlap percentages — Census tracts, congressional districts, state legislative
   areas, school districts

  Coverage:
  - Spatial: United States, Canada
  - Temporal: 2011–2024 (ACS); current month (postal data)
  - Update cadence: monthly (postal), annual (ACS), quarterly (boundaries)

  Access:
  - Free tier: 2,500 lookups/day, no credit card
  - Docs: https://api.zip-codes.com/docs
  - OpenAPI spec: https://api.zip-codes.com/v2/openapi.json