### PR TITLE
Add BailleurVerif (French non-compliant rental listings observatory) under Government

### DIFF
--- a/core/Government/BailleurVerif.yml
+++ b/core/Government/BailleurVerif.yml
@@ -1,0 +1,32 @@
+---
+title: BailleurVerif - French Non-Compliant Rental Listings Observatory
+homepage: https://www.data.gouv.fr/fr/datasets/annonces-de-location-francaises-non-conformes-observatoire-bailleurverif/
+category: Government
+description: Time-stamped longitudinal observatory of French rental listings flagged as non-compliant with the loi ELAN rent-cap (encadrement des loyers) and the DPE F/G rental ban (loi Climat-Résilience). Daily automated scrape across 7 French cities (Paris, Lille, Lyon, Marseille, Bordeaux, Montpellier, Plaisir), 11 git-timestamped waves to date, with cross-wave persistence chain demonstrating that 57.6% of listings flagged in wave-1 remain flagged in wave-3 (N=121 triple-persisted listings). Useful for academic research on landlord compliance, regulatory effectiveness, and housing market opacity.
+version: v1
+keywords:
+  - housing
+  - rental
+  - france
+  - real-estate
+  - regulatory-compliance
+  - loi-elan
+  - dpe
+  - encadrement-loyer
+image:
+temporal: 2026-05-13/ongoing (daily updates 03:00 UTC)
+spatial: France (Paris, Lille, Lyon, Marseille, Bordeaux, Montpellier, Plaisir)
+access_level: public
+copyrights: Open Licence v2.0 (Etalab)
+accrual_periodicity: daily
+specification:
+data_quality: true
+data_dictionary: https://github.com/Creariax5/bailleurverif/blob/main/README.md
+language: fr
+license: etalab-2.0
+publisher: Florian Demartini (BailleurVerif)
+organization: BailleurVerif
+issued_time: 2026-05-13
+sources:
+  - https://www.data.gouv.fr/fr/reuses/bailleurverif-observatoire-annonces-loyer-non-conformes-encadrement-dpe-f-g/
+  - https://github.com/Creariax5/bailleurverif


### PR DESCRIPTION
## New dataset entry

**BailleurVerif** — French non-compliant rental listings observatory (loi ELAN rent-cap + loi Climat-Résilience DPE F/G ban).

### Why it fits the high-quality criteria

- ✅ **Uncommon to obtain legally**: longitudinal cross-wave persistence dataset of *flagged* listings doesn't exist elsewhere — DVF (gov.fr) gives transactions, SeLoger/PAP give listings without compliance flagging. We publish the union: scraped listings + per-field non-compliance reasoning.
- ✅ **Valuable knowledge for a specific domain**: housing-policy researchers, ANIL/ADIL legal advisors, and consumer associations (DAL, FAP, CLCV) currently lack a public time-stamped compliance dataset.
- ✅ **Direct download, no login**: hosted on `data.gouv.fr` (Open Licence v2.0 Etalab) — direct CSV/JSON.
- ✅ **Not promotional**: no ads, no paywall, no signup, no monetization. MIT-licensed code on GitHub.

### Provenance signals

- Hosted on the French government open-data portal `data.gouv.fr` (DR ≈ 90).
- Daily automated scrape, 11 git-timestamped waves (commit `194a4a2`, 2026-05-19T06:35Z).
- Cross-wave persistence chain N=3: 121 listings triple-persisted (57.6% persistence rate), proving non-rejouable historical record.
- Reuse page on data.gouv.fr: https://www.data.gouv.fr/fr/reuses/bailleurverif-observatoire-annonces-loyer-non-conformes-encadrement-dpe-f-g/
- Source code (MIT): https://github.com/Creariax5/bailleurverif

### YAML

Added under `core/Government/BailleurVerif.yml` matching the existing `France.yml` pattern.

Happy to revise category to `Economics` if maintainers prefer (precedent: `Economics/prop-metrics-real-estate-data.yml`).