### PR TITLE
Add Prestyj Lead Response & AI Sales Statistics dataset (SocialSciences)

### DIFF
--- a/core/SocialSciences/Prestyj-Lead-Response-Statistics.yml
+++ b/core/SocialSciences/Prestyj-Lead-Response-Statistics.yml
@@ -1,0 +1,31 @@
+---
+title: Prestyj Lead Response, Video Advertising & AI Sales Statistics Dataset
+homepage: https://prestyj.com/data
+category: SocialSciences
+description: |
+  A curated dataset of 58+ cite-worthy statistics covering speed-to-lead, video
+  advertising performance, AI adoption in sales, lead conversion rates, and
+  cost-per-lead by industry. Each row carries its primary publisher (Harvard
+  Business Review, InsideSales, Wyzowl, HubSpot, WordStream, McKinsey, Gartner,
+  Salesforce, etc.), year of publication, and a stable permalink. Sourced and
+  dated 2024-2026.
+keywords:
+  - lead response time
+  - speed to lead
+  - video advertising
+  - AI in sales
+  - cost per lead
+  - marketing benchmarks
+  - sales operations
+temporal: "2024/2026"
+spatial: United States
+access_level: public
+copyrights: Prestyj
+data_quality: true
+license: CC BY 4.0
+publisher: Prestyj
+sources:
+  - title: Prestyj Statistics — CSV
+    url: https://prestyj.com/data/statistics.csv
+  - title: Prestyj Statistics — JSON
+    url: https://prestyj.com/data/statistics.json


### PR DESCRIPTION
## What

Adds a new dataset entry: **Prestyj Lead Response, Video Advertising & AI Sales Statistics** under `core/SocialSciences/Prestyj-Lead-Response-Statistics.yml`.

## Why it qualifies

- **Free + downloadable directly** (no login, no purchase): https://prestyj.com/data/statistics.csv · https://prestyj.com/data/statistics.json
- **CC BY 4.0** — open license, attribution required.
- **Sourced**: each of the 58 statistics carries its primary publisher (HBR, InsideSales, Wyzowl, HubSpot, WordStream, McKinsey, Gartner, Salesforce, etc.) and year.
- **Schema.org/Dataset** markup with `distribution` on the landing page, so Google Dataset Search and other harvesters can pick it up.
- **Versioned**: dataset `version` and `last_modified` in the JSON payload; mirrored at https://github.com/Gahroot/prestyj-statistics-dataset

The dataset covers areas with limited HQ open data: B2B/B2C lead response time, speed-to-lead conversion curves, video ad creative ROI, AI adoption in sales, and industry CPL benchmarks. Useful for academic research on consumer behaviour and sales operations.

## Checklist

- [x] YAML entry placed in correct category folder (`core/SocialSciences/`)
- [x] Required fields filled: `title`, `homepage`, `category`
- [x] Description, keywords, license, publisher, sources included
- [x] No login wall, paywall, or affiliate gating
- [x] No duplicate of an existing entry

Happy to adjust category (Economics is also plausible) or any field on request.