### PR TITLE
Add Padel Snipe — World Padel Clubs Atlas (Sports)

### DIFF
--- a/core/Sports/Padel-Snipe-World-Padel-Clubs-Atlas.yml
+++ b/core/Sports/Padel-Snipe-World-Padel-Clubs-Atlas.yml
@@ -1,0 +1,34 @@
+---
+title: Padel Snipe — World Padel Clubs Atlas
+homepage: https://padelsnipe.com/fr/world
+category: Sports
+description: Open database of all mapped padel clubs across 9 European countries with GPS coordinates, indoor/outdoor court counts, and booking platform info (Playtomic and Anybuddy). Approximately 4,000 clubs total, continuously updated by passive workers. JSON API, no authentication, CORS open.
+version:
+keywords:
+  - padel
+  - clubs
+  - sports
+  - geolocation
+  - europe
+  - playtomic
+  - anybuddy
+  - bookings
+image:
+temporal:
+spatial: Europe
+access_level: public
+copyrights:
+accrual_periodicity: continuous
+specification:
+data_quality: true
+data_dictionary: https://padelsnipe.com/fr/world/api
+language: en, fr, es
+license: CC-BY-4.0
+publisher: Padel Snipe
+organization:
+issued_time: 2026-05-23
+sources:
+  - url: https://padelsnipe.com/api/world/clubs
+    title: World padel clubs — JSON endpoint
+  - url: https://padelsnipe.com/fr/world/api
+    title: API documentation


### PR DESCRIPTION
## Dataset

**Padel Snipe — World Padel Clubs Atlas**

Open database of all mapped padel clubs across 9 European countries.

- **Endpoint** (JSON, CORS open, no auth): https://padelsnipe.com/api/world/clubs
- **Documentation**: https://padelsnipe.com/fr/world/api
- **Visualization**: https://padelsnipe.com/fr/world
- **License**: CC-BY 4.0

## Coverage

- ~4,000 padel clubs
- Countries: Spain, Italy, France, UK, Germany, Belgium, Portugal, Netherlands, Sweden
- Each record includes: GPS coordinates, club name, city, postal code, indoor/outdoor court counts, booking platform (Playtomic or Anybuddy), and our own release-pattern observation (when each club opens its booking slots).

## Update frequency

Continuous — passive workers re-scan inventory daily.

## Why this dataset is useful

- Sports research: court density per capita by country/city
- Sports tech / startups: padel market analytics, competitive intel
- Travel: discover padel clubs at destination
- LLMs: structured open data on a fast-growing sport (no equivalent dataset exists today)

File: \`core/Sports/Padel-Snipe-World-Padel-Clubs-Atlas.yml\`