### PR TITLE
Add Edges WC2026 Open Fixtures (Sports)

### DIFF
--- a/core/Sports/Edges-WC2026-Open-Fixtures.yml
+++ b/core/Sports/Edges-WC2026-Open-Fixtures.yml
@@ -1,0 +1,31 @@
+---
+title: Edges WC2026 Open Fixtures
+homepage: https://www.edges.co.za/data/wc2026-fixtures/
+category: Sports
+description: Open dataset of all 72 FIFA World Cup 2026 group-stage matches with kickoff times in UTC and South African Standard Time (SAST, UTC+2). CC-BY-4.0. Contains no betting odds, no predictions, no commercial links.
+version: 1.0.0
+keywords: FIFA, World Cup 2026, football, soccer, fixtures, South Africa, SAST, open data
+image:
+temporal: 2026-06-11/2026-06-27
+spatial: United States, Canada, Mexico
+access_level: public
+copyrights: Edges Media (Pty) Ltd
+accrual_periodicity: irregular
+specification:
+data_quality: true
+data_dictionary: https://github.com/puntsza-web/wc2026-fixtures/blob/main/README.md
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: Edges Media (Pty) Ltd
+    web: https://www.edges.co.za
+issued_time: 2026-05-28
+sources:
+  - name: GitHub repository
+    access_url: https://github.com/puntsza-web/wc2026-fixtures
+  - name: Zenodo (DOI 10.5281/zenodo.20430767)
+    access_url: https://doi.org/10.5281/zenodo.20430767
+  - name: Figshare (DOI 10.6084/m9.figshare.32468952)
+    access_url: https://doi.org/10.6084/m9.figshare.32468952
+  - name: Kaggle
+    access_url: https://www.kaggle.com/datasets/puntszaza/edges-wc2026-open-fixtures


### PR DESCRIPTION
Adds a new entry under `core/Sports/` for an open dataset of all 72 FIFA World Cup 2026 group-stage matches with kickoff times in UTC + SAST.

**Dataset:** Edges WC2026 Open Fixtures
**Homepage:** https://www.edges.co.za/data/wc2026-fixtures/
**License:** CC-BY-4.0
**Already deposited on:**
- Zenodo: https://doi.org/10.5281/zenodo.20430767
- Figshare: https://doi.org/10.6084/m9.figshare.32468952
- Kaggle: https://www.kaggle.com/datasets/puntszaza/edges-wc2026-open-fixtures
- GitHub: https://github.com/puntsza-web/wc2026-fixtures

**Disclosure:** The publisher (Edges Media, edges.co.za) is a South African football publication that also operates a sportsbook-affiliate site. The dataset itself contains no betting odds, predictions, or commercial links — it's a factual reference suitable for research, journalism, and SAST-aware scheduling. Disclosing this so the entry stands on its merits.