### PR TITLE
Add Longevity World Cup dataset

### DIFF
--- a/core/Healthcare/Longevity-World-Cup.yml
+++ b/core/Healthcare/Longevity-World-Cup.yml
@@ -1,0 +1,29 @@
+---
+title: Longevity World Cup
+homepage: https://longevityworldcup.com/
+category: Healthcare
+description: Public longevity competition dataset with participant-submitted athlete profiles, biological-age results, biomarker records, proof links, placements, crowd-age fields, and a JSON API for healthspan and age-reduction analytics.
+version: Live
+keywords: longevity, biomarkers, biological age, healthspan, quantified self
+temporal: live participant submissions
+spatial: global
+access_level: public
+copyrights:
+accrual_periodicity: live-site-updated
+specification: https://longevityworldcup.com/llms.txt
+data_quality: false
+data_dictionary: https://longevityworldcup.com/llms.txt
+language: en
+license: Check source terms before redistributing public participant-submitted data
+publisher:
+  - name: Longevity World Cup
+    web: https://longevityworldcup.com/
+organization:
+  - name: Longevity World Cup
+    web: https://longevityworldcup.com/
+sources:
+  - name: Public athletes JSON API
+    access_url: https://longevityworldcup.com/api/data/athletes
+references:
+  - title: LLM-readable leaderboard summary
+    reference: https://longevityworldcup.com/ai/leaderboard.md


### PR DESCRIPTION
## Summary
- Add Longevity World Cup to the Healthcare dataset metadata.
- Link to the canonical site and public athletes JSON API without copying or republishing participant data.

## Fit
LWC exposes a public longevity competition dataset with participant-submitted athlete profiles, biological-age results, biomarker records, proof links, placements, crowd-age fields, and a JSON API useful for healthspan and age-reduction analytics.

## Validation
- `PYTHONUTF8=1 python tests/validate.py`

Note: UTF-8 mode was needed locally on Windows because one existing upstream YAML file contains bytes that fail under the default Windows code page.