### PR TITLE
Add Ai Mining Co. GPU Rental Pricing under Finance

### DIFF
--- a/core/Finance/Ai-Mining-Co-GPU-Rental-Pricing.yml
+++ b/core/Finance/Ai-Mining-Co-GPU-Rental-Pricing.yml
@@ -1,0 +1,22 @@
+---
+title: Ai Mining Co. GPU Rental Pricing
+homepage: https://www.aiminingco.com/data-partners
+category: Finance
+description: Daily GPU rental pricing observations across 29 authorized marketplace partners, covering nearly 100 distinct NVIDIA and AMD GPU SKUs. Tracks on-demand, spot, reserved, and community pricing tiers in USD per GPU-hour with marketplace, region, and tier attribution.
+version:
+keywords: GPU, rental, pricing, compute, NVIDIA, H100, A100, market data
+image:
+temporal: 2025-01-01/..
+spatial: Global
+access_level: public
+copyrights:
+accrual_periodicity: daily
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license:
+publisher:
+organization:
+issued_time: 2026.05
+sources: []


### PR DESCRIPTION
Adds an entry for Ai Mining Co. GPU Rental Pricing under the Finance category.

**What this dataset covers:** Daily GPU rental pricing observations across 29 authorized marketplace partners (including Vast.ai, RunPod, Akash, TensorDock, io.net, Hyperstack, SaladCloud, Cirrascale, Clore.ai, OVHcloud, and others), covering nearly 100 distinct NVIDIA and AMD GPU SKUs. Tracks on-demand, spot, reserved, and community pricing tiers with marketplace attribution, regional metadata, and pricing tier classification.

**Why Finance:** GPU compute hours are emerging as a tradeable commodity (CME Group and Silicon Data announced compute futures on May 12, 2026, pending CFTC review). This dataset fits the same category as existing Finance entries that publish daily market pricing - Quandl, CBOE Futures Exchange, NASDAQ, Yahoo Finance, OANDA.

**Update cadence:** Daily UTC snapshots.

**Access:** Public summary access (free with signup). Schema.org Dataset markup published at the homepage URL for machine-readable metadata.

**Documentation:** Methodology and partner list at https://www.aiminingco.com/data-partners.
