### PR TITLE
Add: Romania Medical Waste Procurement Dataset (Healthcare)

### DIFF
--- a/core/Healthcare/Romania-Medical-Waste-Procurement-Dataset.yml
+++ b/core/Healthcare/Romania-Medical-Waste-Procurement-Dataset.yml
@@ -1,0 +1,26 @@
+---
+title: Romanian Hazardous Medical Waste Procurement Dataset (CPV 9052*)
+homepage: https://licitatiimedicale.com/dataset
+category: Healthcare
+description: Open dataset of all publicly available contract award notices from the European Union's Tenders Electronic Daily (TED) for services related to hazardous medical waste management in Romania (CPV 9052*). 487+ contracts covering 155 hospitals and 49 operators, period 2019-2026, cumulative value 898 million RON. Includes Tukey IQR-based statistical outlier detection methodology, per-hospital and per-operator profiles, and free price-check calculator.
+version: 1.0
+keywords: medical waste, public procurement, Romania, CPV 9052, TED, hospital procurement, hazardous waste, market concentration, Tukey IQR
+access_level: public
+language: ro, en
+spatial: Romania
+temporal: 2019-2026
+copyrights: Creative Commons Attribution 4.0 International (CC BY 4.0)
+license: https://creativecommons.org/licenses/by/4.0/
+data_quality: true
+publisher:
+  - name: Licitații Medicale
+    web: https://licitatiimedicale.com
+organization:
+  - name: Licitații Medicale
+    web: https://licitatiimedicale.com
+issued_time: 2026-06-03
+sources:
+  - https://github.com/licitatiimedicale/data
+  - https://licitatiimedicale.com/api/v1/awards.csv
+  - https://licitatiimedicale.com/api/v1/awards
+  - https://www.wikidata.org/wiki/Q140042781


### PR DESCRIPTION
Adds Romania Medical Waste Procurement Dataset to Healthcare category.

**Details:**
- 487 contract award notices (CPV 9052*) for hazardous medical waste services in Romania
- 155 hospitals and 49 operators covered
- Period: August 2019 — April 2026
- Cumulative value: 898 million RON
- Source: TED (Tenders Electronic Daily, EU Official Journal)
- License: CC BY 4.0
- Methodology: Tukey IQR (1977) outlier detection
- Wikidata: Q140042781
- GitHub: https://github.com/licitatiimedicale/data
- CSV download: https://licitatiimedicale.com/api/v1/awards.csv
- JSON API: https://licitatiimedicale.com/api/v1/awards

**Use cases:**
- Public procurement transparency research
- Investigative journalism (Romanian health sector)
- Academic studies (market concentration, anomaly detection)
- Audit teams (hospital procurement compliance)

All 10 case study analyses use exclusively official public sources (TED, ANAP, CNSC, Romanian Competition Council).