### PR TITLE
Add Korea: MiniLex 7-domain Korean lawdata (wellsa-ai)

### DIFF
--- a/core/Government/Korea-MiniLex.yml
+++ b/core/Government/Korea-MiniLex.yml
@@ -1,0 +1,33 @@
+---
+title: South Korea — MiniLex 7-domain Korean lawdata (wellsa-ai)
+homepage: https://minilex.wellsa.ai
+category: Government
+description: Korean public legal data (statutes, administrative rules, court precedents, statutory interpretations, constitutional court decisions, local ordinances, treaties) unified into 7 Markdown corpora. 397K+ documents indexed in production demo with source-cited Q&A. MIT licensed, daily cron updates with Git history provenance.
+version: '1.0'
+keywords:
+  - korea
+  - korean
+  - legal
+  - law
+  - statutes
+  - administrative-rules
+  - precedents
+  - constitutional
+  - local-ordinances
+  - treaties
+  - rag
+  - public-data
+  - markdown
+image:
+temporal: 1905-present
+spatial: South Korea
+access_level: Public
+copyrights:
+accrual_periodicity: Daily
+specification:
+data_quality: true
+data_dictionary:
+language: Korean
+license: MIT
+publisher: wellsa-ai (Korean Ministry of Government Legislation public OpenAPI)
+organization: wellsa-ai


### PR DESCRIPTION
## Summary

Adds a new `Government/Korea-MiniLex.yml` entry.

**MiniLex 7-domain Korean lawdata (wellsa-ai)** unifies 7 Korean public legal corpora into a Markdown-first dataset infrastructure:

- statutes (5,589)
- administrative rules (10,765)
- court precedents (171,014)
- statutory interpretations (8,728)
- constitutional court decisions (38,092)
- local ordinances (159,910)
- treaties (6,907, 1905~2026)

Total: 397K+ Markdown documents, MIT licensed, daily cron updates with Git history.

## Resources

- Production demo: https://minilex.wellsa.ai (1.36M+ articles indexed, source-cited Q&A)
- HF org (7 sibling datasets): https://huggingface.co/wellsa-ai
- GitHub canonical: https://github.com/wellsa-ai

Korea entry was not present in the Government category. Source data comes from the Korean Ministry of Government Legislation's public OpenAPI; wellsa-ai provides the Markdown normalization + daily cron layer.

Happy to adjust metadata if needed!