### PR TITLE
Add State of Peptides 2026 under Chemistry

### DIFF
--- a/core/Chemistry/state-of-peptides-2026.yml
+++ b/core/Chemistry/state-of-peptides-2026.yml
@@ -1,0 +1,18 @@
+---
+title: State of Peptides 2026
+homepage: https://peptahub.com/state-of-peptides-2026
+category: Chemistry
+description: Open reference dataset of 156 peptide and peptide-adjacent compounds. Each record carries a legal/regulatory status bucket (prescription, research-only, unregulated, reclassification-pending, legal-compounding), category, routes of administration, half-life, molecular weight, CAS number, peer-reviewed reference count, external knowledge-graph identifiers (PubChem CID, DrugBank, Wikidata, Wikipedia), and a profile URL. Downloadable directly as CSV and JSON.
+version: 2026.06.09
+keywords: peptides, pharmacology, GLP-1, chemistry, regulatory status, reference data, open data
+access_level: public
+language: en
+license: CC BY 4.0
+publisher:
+  - name: PeptaHub
+    web: https://peptahub.com
+sources:
+  - name: State of Peptides 2026 (CSV)
+    access_url: https://peptahub.com/state-of-peptides-2026/dataset.csv
+  - name: State of Peptides 2026 (JSON)
+    access_url: https://peptahub.com/state-of-peptides-2026/dataset.json


### PR DESCRIPTION
This PR adds the **State of Peptides 2026** open dataset under `core/Chemistry/`.

Why it fits the high-quality criteria:
- **Open + directly downloadable**, no login or purchase: CSV and JSON are served directly (https://peptahub.com/state-of-peptides-2026/dataset.csv , https://peptahub.com/state-of-peptides-2026/dataset.json).
- **Valuable domain knowledge**: 156 peptide and peptide-adjacent compounds with legal/regulatory status buckets, categories, routes, half-life, molecular weight, CAS numbers, peer-reviewed reference counts, and external knowledge-graph identifiers (PubChem/DrugBank/Wikidata/Wikipedia).
- **Licensed for reuse**: CC BY 4.0.

Entry uses the three required fields (`title`, `homepage`, `category: Chemistry` matching the folder) plus optional metadata.

Disclosure: submitted by a contributor affiliated with PeptaHub, the dataset publisher. It is an educational/reference dataset, not medical advice or a vendor list.