### PR TITLE
Add Australian Church Directory under SocialSciences

### DIFF
--- a/core/SocialSciences/australian-church-directory.yaml
+++ b/core/SocialSciences/australian-church-directory.yaml
@@ -1,0 +1,10 @@
+---
+title: Australian Church Directory
+homepage: https://auschurches.com.au/about/data
+category: SocialSciences
+description: 5,106 active Christian church listings across all 8 Australian states and territories, covering 40 denominations and 2,333 suburbs. Each record includes name, denomination, address, suburb, postcode, latitude, longitude, website, phone, and a permanent profile URL. Available as CSV and JSON with schema.org Dataset JSON-LD documentation.
+keywords: churches, Christianity, religion, Australia, denominations, religious geography, directory
+access_level: public
+license: CC-BY-4.0
+language: en
+issued_time: 2026


### PR DESCRIPTION
Adds the Australian Church Directory (auschurches.com.au) open dataset under `SocialSciences`.

5,106 active Christian church listings across all 8 Australian states and territories, covering 40 denominations and 2,333 suburbs. Each record includes name, denomination, address, suburb, postcode, latitude, longitude, website, phone, and a permanent profile URL.

- Documentation, schema, and download links: https://auschurches.com.au/about/data
- License: CC-BY 4.0
- Distribution: CSV (~1.5 MB) and JSON (~8.8 MB), free and direct-download (no login or paywall)
- Also discoverable via schema.org `Dataset` JSON-LD on the documentation page

YAML added at `core/SocialSciences/australian-church-directory.yaml`. Validated locally against `tests/validate.py` checks (required fields present, category matches folder).