### PR TITLE
Add US Vehicle Failure-Mileage & Reliability datasets under Transportation

### DIFF
--- a/core/Transportation/ProblemsByVin-NHTSA-Vehicle-Reliability.yml
+++ b/core/Transportation/ProblemsByVin-NHTSA-Vehicle-Reliability.yml
@@ -1,0 +1,22 @@
+---
+title: US Vehicle Failure-Mileage & Reliability Datasets (NHTSA-derived)
+homepage: https://problemsbyvin.com/data/
+category: Transportation
+description: Open datasets derived from 800,000+ US NHTSA owner complaints and recalls across 5,600+ vehicles (model years 2005-2025). Includes failure-mileage quartiles (the odometer reading at which specific component failures are reported, parsed from the NHTSA ODI flat file), post-warranty failure patterns, engine and transmission complaint density, and a recall-gap index cross-checked against the live NHTSA recalls API. Direct CSV and JSON download, no login required.
+version:
+keywords: automotive, vehicles, reliability, NHTSA, owner complaints, recalls, failure mileage, defects
+image:
+temporal: 2005-2025
+spatial: United States
+access_level: public
+copyrights: CC BY 4.0
+accrual_periodicity: weekly
+specification:
+data_quality: false
+data_dictionary: https://problemsbyvin.com/data/
+language: en
+license: https://creativecommons.org/licenses/by/4.0/
+publisher: ProblemsByVin
+organization: ProblemsByVin
+issued_time: 2026
+sources: []


### PR DESCRIPTION
Adds an open, NHTSA-derived vehicle reliability dataset under **Transportation**.

**What it is:** datasets built from 800,000+ US NHTSA owner complaints and recalls across 5,600+ vehicles (MY 2005-2025). The derived layer — failure-mileage quartiles (odometer reading at which specific component failures are reported, parsed from the NHTSA ODI flat file), post-warranty failure patterns, engine/transmission complaint density, and a recall-gap index — is not available from the raw NHTSA API.

**Meets the quality criteria:**
- Direct CSV + JSON download, **no login/paywall** (e.g. https://problemsbyvin.com/data/failure-mileage-distribution.json)
- Released **CC BY 4.0**
- Contributes domain knowledge (complaint-mileage aggregation) not otherwise available openly
- Complements the existing NHTSA FARS entry in this section

Required fields (title/homepage/category) set; category matches the folder.