### PR TITLE
Add World Company Database under Economics

### DIFF
--- a/core/Economics/World-Company-Database.yml
+++ b/core/Economics/World-Company-Database.yml
@@ -1,0 +1,31 @@
+---
+title: World Company Database
+homepage: https://github.com/Alessandro114/world-company-database
+category: Economics
+description: 250M+ company records from 50+ countries with revenue, employees, and credit scores. Free API and bulk download available.
+version:
+keywords: companies, business, revenue, employees, credit scores, global
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license:
+publisher:
+  - name:
+    web:
+organization:
+  - name:
+    web:
+issued_time:
+sources:
+  - name:
+    access_url:
+references:
+  - title:
+    reference:


### PR DESCRIPTION
## New Dataset Entry

**Title**: World Company Database  
**Category**: Economics  
**Homepage**: https://github.com/Alessandro114/world-company-database  

### Description

250M+ company records from 50+ countries with revenue, employees, and credit scores. Free API and bulk download available.

### Checklist

- [x] Entry created from `PULL_REQUEST_TEMPLATE.yml` format
- [x] Required fields (`title`, `homepage`, `category`) are present
- [x] Category matches the folder name (`Economics`)
- [x] Dataset is publicly accessible
- [x] No advertisements or spam