### PR TITLE
Add M&A Multiples Index dataset (Finance)

### DIFF
--- a/core/Finance/MA-Multiples-Index.yml
+++ b/core/Finance/MA-Multiples-Index.yml
@@ -1,0 +1,31 @@
+---
+title: M&A Multiples Index (SMB & Lower-Middle-Market)
+homepage: https://github.com/nickcals/multiples
+category: Finance
+description: Open dataset of median EV/EBITDA and EV/Revenue valuation multiples for small-business and lower-middle-market mergers and acquisitions, broken out by sub-vertical and enterprise-value bracket. Derived from disclosed multiples in 25,000+ completed transactions (SEC EDGAR 8-K/S-4 filings, fairness opinions, and verified press releases); each published cell requires at least 10 disclosed deals, with no estimated or imputed values. Source window 2018-2026. Provided as machine-readable JSON.
+version: 1.0
+keywords: M&A, mergers and acquisitions, valuation, EV/EBITDA, EV/Revenue, multiples, private equity, SMB, middle market, finance.
+image:
+temporal: 2018-2026
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity: weekly
+specification: https://specs.frictionlessdata.io/
+data_quality: false
+data_dictionary: https://github.com/nickcals/multiples#schema-multiplesjson
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: ExitValue.ai
+    web: https://exitvalue.ai/methodology
+organization:
+  - name: ExitValue.ai
+    web: https://exitvalue.ai
+issued_time: 2026.06
+sources:
+  - name: Live JSON (continuously updated)
+    access_url: https://exitvalue.ai/data/multiples.json
+references:
+  - title: Dataset DOI (Zenodo)
+    reference: https://doi.org/10.5281/zenodo.20398222


### PR DESCRIPTION
Open dataset of median EV/EBITDA and EV/Revenue valuation multiples for SMB and lower-middle-market M&A, by sub-vertical and EV bracket, from 25,000+ disclosed transactions (SEC EDGAR + verified press releases). CC-BY-4.0, directly downloadable as JSON, no login/paywall.

---
title: 38-Cloud
homepage: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset
category: EarthScience
description: Contains 38 Landsat 8 scene images and their manually extracted pixel-level ground truths for cloud detection. They are cropped into multiple 384*384 patches. It has 8400 patches for training and 9201 patches for testing.
version: 1.0
keywords: Landsat 8, cloud detection, image segmentation, semantic segmentation.
image: https://github.com/SorourMo/38-Cloud-A-Cloud-Segmentation-Dataset/blob/master/sample/blue_patch_192_10_by_12_LC08_L1TP_002053_20160520_20170324_01_T1.jpg
temporal:
spatial: 384*384
access_level: public
copyrights:
accrual_periodicity: 
specification:
data_quality: false
data_dictionary: 
language: en
license: Apache License
publisher:
  - name: 
    web: 
organization:
  - name: Laboratory for Robotic Vision (LRV), School of Engineering Science, Simon Fraser University, Canada
    web: 
issued_time: 2019.02
sources:
  - name: 
    access_url: 
references:
  - title: 
    reference: 
