### PR TITLE
Add HF dataset link and Zenodo DOI to OpenChainBench

### DIFF
--- a/core/Finance/OpenChainBench.yml
+++ b/core/Finance/OpenChainBench.yml
@@ -23,6 +23,8 @@ organization:
 sources:
   - name: OpenChainBench JSON API
     access_url: https://openchainbench.com/api/stat/l1-finality
+  - name: Hugging Face Dataset
+    access_url: https://huggingface.co/datasets/OpenChainBench/benchmarks
 references:
-  - title:
-    reference:
+  - title: Zenodo concept DOI
+    reference: https://doi.org/10.5281/zenodo.20800311


### PR DESCRIPTION
Adds the Hugging Face dataset link and Zenodo concept DOI to the existing OpenChainBench entry in core/Finance.

- HF dataset: https://huggingface.co/datasets/OpenChainBench/benchmarks (daily Parquet snapshots)
- Zenodo DOI: https://doi.org/10.5281/zenodo.20800311