### PR TITLE
Add US Farmers Market Statistics 2026 under Agriculture

### DIFF
--- a/core/Agriculture/US-Farmers-Market-Statistics-2026.yml
+++ b/core/Agriculture/US-Farmers-Market-Statistics-2026.yml
@@ -1,0 +1,22 @@
+---
+title: US Farmers Market Statistics 2026
+homepage: https://harvestlymarkets.com/farmers-market-statistics/
+category: Agriculture
+description: State-by-state statistics for ~7,056 US farmers markets — per-state counts, SNAP/EBT acceptance share (~13%), certified-organic share (~15%), and share with a working website (~31%). Downloadable as CSV and JSON. Derived from the USDA AMS Local Food Portal.
+version:
+keywords: farmers markets, local food, SNAP, EBT, organic, USDA, agriculture
+image:
+temporal: 2026
+spatial: United States
+access_level: public
+copyrights: CC BY 4.0
+accrual_periodicity:
+specification: https://harvestlymarkets.com/farmers-market-statistics/
+data_quality: true
+data_dictionary:
+language: en
+license: CC BY 4.0
+publisher: Harvestly Markets
+organization: Harvestly Markets
+issued_time: 2026.06
+sources: []


### PR DESCRIPTION
Adds one Agriculture-category entry via apd-core (not editing the generated README).

Open national dataset: US farmers markets by state, with SNAP/EBT and certified-organic fields. CSV + JSON, CC BY 4.0, derived from the USDA AMS Local Food Portal. Stable landing page documents methodology and license. Followed CONTRIBUTING.md; required fields (title, homepage, category) set, category matches the folder.