### PR TITLE
Add FilingFirehose under Finance

### DIFF
--- a/core/Finance/FilingFirehose.yml
+++ b/core/Finance/FilingFirehose.yml
@@ -1,0 +1,31 @@
+---
+title: FilingFirehose
+homepage: https://filingfirehose.com
+category: Finance
+description: Structured, normalized SEC EDGAR filings API with body-text parsing that goes beyond filer-reported items. Free public endpoints expose the last 72 hours of parsed 8-K filings (with classifier flagging suspected misclassifications under Item 8.01 — e.g. cyber incidents buried as Other Events, silent officer departures), Schedule 13D/G filings (tagged when filer matches known activist funds — Saba, Bulldog, Karpus, Icahn, Elliott, Starboard, Pershing, +14 more), and S-3 / 424B5 shelf and ATM-offering detection with sales-agent extraction. A free per-ticker forensic risk score (LOW / MODERATE / ELEVATED / HIGH) at /forensic/score?ticker=SYM aggregates buried cyber, dilution, restatement, officer departure, and bankruptcy signals across 8-K / 10-K / 10-Q / S-3 filings. OpenAPI spec at /openapi.json. MCP server at /mcp.
+version: 1.0
+keywords: Finance, SEC, EDGAR, Filings, 8-K, 13D, 10-K, S-3, ATM, Forensic, Activist
+image: https://filingfirehose.com/static/logo.png
+temporal: rolling 72-hour window on free tier; full archive on paid tier
+spatial: United States
+access_level: public
+copyrights:
+accrual_periodicity: continuous
+specification: https://filingfirehose.com/openapi.json
+data_quality: true
+data_dictionary: https://filingfirehose.com/docs
+language: en
+license:
+publisher:
+  - name: FilingFirehose
+    web: https://filingfirehose.com
+organization:
+  - name: FilingFirehose
+    web: https://filingfirehose.com
+issued_time: 2026.04
+sources:
+  - name: U.S. Securities and Exchange Commission EDGAR
+    access_url: https://www.sec.gov/edgar
+references:
+  - title: OpenAPI Specification
+    reference: https://filingfirehose.com/openapi.json


### PR DESCRIPTION
Adds [FilingFirehose](https://filingfirehose.com) under the **Finance** category.

FilingFirehose is a structured/normalized SEC EDGAR filings API. Free public endpoints (no signup, no login) expose:

- Parsed **8-K** filings with a body-text classifier that flags suspected misclassifications under Item 8.01 (cyber incidents buried as "Other Events", silent officer departures, etc.)
- Parsed **Schedule 13D/G** filings with activist filer tagging (Saba, Bulldog, Karpus, Icahn, Elliott, Starboard, Pershing, +14 more)
- Parsed **S-3 / 424B5** prospectuses with shelf size, ATM-offering detection, and sales-agent extraction
- A free per-ticker **forensic risk score** (LOW / MODERATE / ELEVATED / HIGH) at `/forensic/score?ticker=SYM`

Free tier rolling 72-hour window; full archive available on paid tier (does not bar discovery / direct download of the public surface).

- Homepage: https://filingfirehose.com
- OpenAPI: https://filingfirehose.com/openapi.json
- MCP: https://filingfirehose.com/mcp

Sits alongside the existing `SEC-EDGAR.yml` entry — FilingFirehose builds value-add structure on top of raw EDGAR.
