### PR TITLE
Add US State Name-Change (DMV) Requirements dataset (Government)

### DIFF
--- a/core/Government/NameChangePacket-US-State-Requirements.yml
+++ b/core/Government/NameChangePacket-US-State-Requirements.yml
@@ -1,0 +1,31 @@
+---
+title: US State Name-Change (DMV) Requirements
+homepage: https://namechangepacket.com/name-change-requirements-by-state
+category: Government
+description: State-by-state requirements for updating a driver's license or state ID after a legal name change across 46 verified US jurisdictions. Each record covers the DMV agency name, license fee, in-person requirement, deadline, required document count, and a link to the official .gov source. Downloadable as CSV or JSON.
+version:
+keywords: name change, DMV, driver license, state ID, government forms, US states
+image:
+temporal:
+spatial: United States
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: NameChangePacket
+    web: https://namechangepacket.com/
+organization:
+  - name: NameChangePacket
+    web: https://namechangepacket.com/
+issued_time:
+sources:
+  - name: US State Name-Change Requirements (CSV/JSON)
+    access_url: https://namechangepacket.com/name-change-requirements-by-state
+references:
+  - title:
+    reference:


### PR DESCRIPTION
Adds one YAML entry under `core/Government/`: a state-by-state dataset of driver-license / state-ID name-change requirements across 46 verified US jurisdictions.

Each record includes the DMV agency name, license fee, in-person requirement, deadline, required document count, and a link to the official .gov source. It is freely viewable and **directly downloadable as CSV or JSON** (no login or purchase), released under CC-BY-4.0.

- Dataset page (with CSV/JSON download): https://namechangepacket.com/name-change-requirements-by-state

Meets the quality criteria: it contributes valuable domain-specific knowledge, is downloadable directly from the linked site, and carries no ads. Formatted from `PULL_REQUEST_TEMPLATE.yml`.