### PR TITLE
Add Cron and Scheduled-Job Failure-Mode Taxonomy dataset (Software)

### DIFF
--- a/core/Software/Cron-Job-Failure-Taxonomy.yml
+++ b/core/Software/Cron-Job-Failure-Taxonomy.yml
@@ -1,0 +1,22 @@
+---
+title: Cron and Scheduled-Job Failure-Mode Taxonomy
+homepage: https://cronshield.com/data/cron-failure-taxonomy
+category: Software
+description: A taxonomy of cron and scheduled-job failure modes - exit code or signal, meaning, typical cause, and remediation - each source-cited. CSV and JSON.
+version: "1.0"
+keywords: cron, scheduled jobs, devops, monitoring, exit codes, signals, sysadmin
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license: CC-BY-4.0
+publisher: CronShield
+organization:
+issued_time: "2026-07-05"
+sources: []


### PR DESCRIPTION
Adds a free, openly-licensed (CC BY 4.0) primary-source-cited dataset. Files (CSV + JSON) and full data card are linked from the homepage.