### PR TITLE
Add Global Solo Banking Access Index under Finance

### DIFF
--- a/core/Finance/Global-Solo-Banking-Access-Index.yml
+++ b/core/Finance/Global-Solo-Banking-Access-Index.yml
@@ -1,0 +1,33 @@
+---
+title: Global Solo Banking Access Index
+homepage: https://www.globalsolo.global/data/banking-access-index
+category: Finance
+description: Evidence-cited matrix of which US business-banking providers accept non-resident founders. 18 providers (15 fintechs plus Chase, Bank of America, Wells Fargo) scored against 8 countries (India, China, UK, Canada, Pakistan, Nigeria, Turkey, Brazil). 239 claims, each carrying a verbatim quote from the provider's published policy, source URL, source tier, and access date, adversarially re-verified against the sources. Country cells are tri-state (explicit accept / explicit restrict / no published restriction) — absence from a prohibited list is never converted into acceptance. CSV and JSON downloads; the JSON includes the full evidence appendix with quotes. Re-verified quarterly.
+version: 1.0
+keywords: banking, fintech, non-resident, US LLC, cross-border, KYC, business bank account, country restrictions, financial access.
+image:
+temporal: 2026
+spatial: United States; founder countries India, China, UK, Canada, Pakistan, Nigeria, Turkey, Brazil
+access_level: public
+copyrights:
+accrual_periodicity: quarterly
+specification:
+data_quality: false
+data_dictionary: https://www.globalsolo.global/about/methodology#banking-access-index
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: Global Solo
+    web: https://www.globalsolo.global/about/methodology
+organization:
+  - name: Global Solo
+    web: https://www.globalsolo.global
+issued_time: 2026.07
+sources:
+  - name: CSV download
+    access_url: https://www.globalsolo.global/data/banking-access-index.csv
+  - name: JSON download (with evidence appendix)
+    access_url: https://www.globalsolo.global/data/banking-access-index.json
+references:
+  - title: Methodology
+    reference: https://www.globalsolo.global/about/methodology#banking-access-index


### PR DESCRIPTION
Adds the **Global Solo Banking Access Index** to `core/Finance/`.

**What it is**: an evidence-cited matrix of which US business-banking providers accept non-resident founders — 18 providers (15 fintechs + Chase, Bank of America, Wells Fargo) × 8 founder countries (India, China, UK, Canada, Pakistan, Nigeria, Turkey, Brazil). 239 claims, each with a verbatim quote from the provider's published policy, source URL, and access date; every claim adversarially re-verified against its source. Country cells are tri-state (explicit accept / explicit restrict / no published restriction) so absence from a prohibited list is never presented as acceptance.

**Access**: CC BY 4.0, direct CSV + JSON downloads (no login), JSON includes the full evidence appendix. Re-verified quarterly.

- Page: https://www.globalsolo.global/data/banking-access-index
- CSV: https://www.globalsolo.global/data/banking-access-index.csv
- JSON: https://www.globalsolo.global/data/banking-access-index.json
- Methodology: https://www.globalsolo.global/about/methodology#banking-access-index

**Disclosure**: I'm the publisher (Global Solo, a comparison site for cross-border founders). The site has affiliate relationships with some listed providers; the dataset page itself carries no affiliate links, and the methodology page documents the evidence rules.