### PR TITLE
Add AirPop Respirator & Barrier-Mask Certification Standards Comparison under Healthcare

### DIFF
--- a/core/Healthcare/AirPop-Respirator-Mask-Certification-Standards.yml
+++ b/core/Healthcare/AirPop-Respirator-Mask-Certification-Standards.yml
@@ -1,0 +1,32 @@
+title: AirPop Respirator & Barrier-Mask Certification Standards Comparison
+homepage: https://getairpop.com/blog/mask-testing-methodology-how-certifications-work
+category: Healthcare
+description: A cross-jurisdiction comparison of the major respiratory protection standards (N95 / NIOSH, KN95 / GB 2626-2019, KF94 / MFDS, FFP2 / EN 149) and the ASTM F3502-21 consumer barrier-face-covering standard. For each standard it records minimum filtration and test aerosol, test flow rate, whole-mask leakage/fit requirement, inhalation and exhalation breathing-resistance limits (in pascals), whether source control is tested, and the certifying body. Values are drawn from each standard's public specification. Six records, CSV and JSON. Intended for buyers, procurement teams, journalists, and researchers who need an apples-to-apples reference for what each mask certification actually tests.
+version: 1.0
+keywords: n95, kn95, kf94, ffp2, astm f3502, respirator, mask certification, ppe, air quality, filtration, niosh
+image:
+temporal: 2026
+spatial: USA, China, South Korea, European Union
+access_level: public
+copyrights: AirPop
+accrual_periodicity: annual
+specification:
+data_quality: false
+data_dictionary: https://getairpop.com/blog/mask-testing-methodology-how-certifications-work
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: AirPop
+    web: https://getairpop.com
+organization:
+  - name: AirPop
+    web: https://getairpop.com
+issued_time: 2026.07
+sources:
+  - name: CSV download
+    access_url: https://getairpop.com/data/mask-certification-standards.csv
+  - name: JSON download
+    access_url: https://getairpop.com/data/mask-certification-standards.json
+references:
+  - title: Mask Testing Methodology - How Certifications Work
+    reference: https://getairpop.com/blog/mask-testing-methodology-how-certifications-work


### PR DESCRIPTION
## Add: AirPop Respirator & Barrier-Mask Certification Standards Comparison (Healthcare)

**What it is:** An openly-licensed (CC BY 4.0) cross-jurisdiction comparison of the major respiratory-protection standards — **N95** (NIOSH 42 CFR 84), **KN95** (GB 2626-2019), **KF94** (MFDS), **FFP2** (EN 149:2001+A1:2009) — and the **ASTM F3502-21** consumer barrier-face-covering standard. Six records × the fields buyers and researchers actually need: minimum filtration & test aerosol, test flow rate, whole-mask leakage/fit requirement, inhalation and exhalation breathing-resistance limits (in pascals), whether source control is tested, and the certifying body. Values are drawn from each standard's public specification. The JSON carries per-standard source citations plus an explicit caveat that the filtration column is **not** directly comparable across respirator and barrier-mask standards (F3502's L1/L2 figures are whole-mask category floors, not filter-material efficiencies).

This fills a gap I noticed in the Healthcare category — there is currently no air-quality / PPE / mask-standard reference dataset in the list.

**Access (public, no login):**
- Landing page / data dictionary: https://getairpop.com/blog/mask-testing-methodology-how-certifications-work
- CSV: https://getairpop.com/data/mask-certification-standards.csv
- JSON: https://getairpop.com/data/mask-certification-standards.json
- License: CC BY 4.0 · Cadence: reviewed annually

**Disclosure:** I'm the publisher — AirPop is a commercial air-wearables brand. The dataset itself is factual public-standard data under CC BY 4.0, and the dataset/download pages carry no affiliate links.
