### PR TITLE
Add Dead Web Index and AI-Crawler Blocking Index under ComputerNetworks

### DIFF
--- a/core/ComputerNetworks/AI-Crawler-Blocking-Index.yml
+++ b/core/ComputerNetworks/AI-Crawler-Blocking-Index.yml
@@ -1,0 +1,33 @@
+---
+title: 'AI-Crawler Blocking Index: robots.txt census of the top 1M domains'
+homepage: https://crawlora.net/ai-crawler-index
+category: ComputerNetworks
+description: A robots.txt census of the Tranco top 1,000,000 domains measuring what share of the web blocks major AI crawlers (GPTBot, CCBot, ClaudeBot, Bytespider, Amazonbot, Google-Extended, and more). Finds that 9.33% of all domains, and 14.8% of the 63% that serve a robots.txt, fully block at least one major AI crawler, with rates broken down by crawler, website category, and TLD.
+version: 1.0.0
+keywords: robots.txt, ai crawlers, gptbot, ccbot, claudebot, web scraping, ai training data, bot blocking, internet measurement
+image:
+temporal: 2026
+spatial: Worldwide
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: true
+data_dictionary: https://github.com/Crawlora-org/ai-crawler-blocking-index-data#readme
+language: en
+license: CC BY 4.0
+publisher:
+- name: Crawlora
+  web: https://crawlora.net
+organization:
+- name: Crawlora
+  web: https://crawlora.net
+issued_time: 2026
+sources:
+- name: Dataset repository (results.jsonl.gz, ~1M rows)
+  access_url: https://github.com/Crawlora-org/ai-crawler-blocking-index-data
+- name: Interactive study page
+  access_url: https://crawlora.net/ai-crawler-index
+references:
+- title: Dataset also mirrored on Hugging Face, Kaggle, and Zenodo (DOI 10.5281/zenodo.20774249)
+  reference: https://doi.org/10.5281/zenodo.20774249

--- a/core/ComputerNetworks/Dead-Web-Index.yml
+++ b/core/ComputerNetworks/Dead-Web-Index.yml
@@ -1,0 +1,33 @@
+---
+title: 'Dead Web Index: reachability census of the top 10M domains'
+homepage: https://crawlora.net/dead-web-index
+category: ComputerNetworks
+description: A reachability census of the top 10 million domains (DomCop top-10M ranking), probed with both a polite-bot client and a real-browser (Chrome TLS/JA3) client. Classifies every domain as alive, dead (DNS failure), blocked (anti-bot/WAF), or redirect, and finds roughly 14% of the web's most popular domains are dead. Includes a companion story on notable shut-down domains.
+version: 1.0.0
+keywords: dead web, link rot, domain reachability, dns, anti-bot, web crawling, internet infrastructure, website availability
+image:
+temporal: 2026
+spatial: Worldwide
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: true
+data_dictionary: https://github.com/Crawlora-org/dead-web-index-data#readme
+language: en
+license: CC BY 4.0
+publisher:
+- name: Crawlora
+  web: https://crawlora.net
+organization:
+- name: Crawlora
+  web: https://crawlora.net
+issued_time: 2026
+sources:
+- name: Dataset repository (zstd-chunked JSONL, ~10M rows per arm)
+  access_url: https://github.com/Crawlora-org/dead-web-index-data
+- name: Interactive study page
+  access_url: https://crawlora.net/dead-web-index
+references:
+- title: How much of the web is actually dead? (Crawlora blog)
+  reference: https://crawlora.net/blog/how-much-of-the-web-is-dead-2026


### PR DESCRIPTION
This PR adds two open datasets from Crawlora under `core/ComputerNetworks`:

1. **Dead Web Index** — a reachability census of the top 10 million domains (DomCop top-10M ranking), probed with both a polite-bot client and a real-browser (Chrome TLS/JA3) client, classifying each domain as alive, dead (DNS failure), blocked, or redirect. ~14% of the most popular domains on the web are dead. CC BY 4.0, ~10M rows/arm, downloadable directly (no login/purchase).
2. **AI-Crawler Blocking Index** — a robots.txt census of the Tranco top 1,000,000 domains measuring what share of the web blocks major AI crawlers (GPTBot, CCBot, ClaudeBot, Bytespider, Amazonbot, Google-Extended). 9.33% of all domains fully block at least one major AI crawler. CC BY 4.0, ~1M rows, also mirrored on Hugging Face/Kaggle/Zenodo, downloadable directly.
Both entries follow the `PULL_REQUEST_TEMPLATE.yml` schema with `title`, `homepage`, and `category` set to `ComputerNetworks` (matching the folder), plus full metadata (license, sources, keywords, description).