### PR TITLE
Add three FactDen sample datasets: G2 reviews, Trip.com/Ctrip hotel reviews, Indeed job postings

### DIFF
--- a/core/Economics/Indeed-Job-Postings-Sample-Dataset-2026.yml
+++ b/core/Economics/Indeed-Job-Postings-Sample-Dataset-2026.yml
@@ -1,0 +1,22 @@
+---
+title: Indeed Job Postings Sample Dataset (2026)
+homepage: https://huggingface.co/datasets/fact-den/indeed-job-postings-2026
+category: Economics
+description: Structured Indeed job postings with parsed numeric salaries (min/max, period, currency), locations, job types, remote flags, benefits and company attributes. CSV/JSON.
+version:
+keywords: jobs,salaries,labor-market,employment,hiring
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license:
+publisher: FactDen
+organization:
+issued_time:
+sources: []

--- a/core/SocialNetworks/G2-Software-Reviews-Sample-Dataset.yml
+++ b/core/SocialNetworks/G2-Software-Reviews-Sample-Dataset.yml
@@ -1,0 +1,22 @@
+---
+title: G2 Software Reviews Sample Dataset (500 reviews, 27 fields)
+homepage: https://huggingface.co/datasets/fact-den/g2-team-collaboration-reviews-sample
+category: SocialNetworks
+description: 500 structured G2 reviews across 5 team-collaboration tools - overall rating, six sub-ratings, structured pros/cons, switched-from competitor and reviewer context. CSV/JSON/JSONL, also mirrored on Kaggle.
+version:
+keywords: reviews,b2b,software,saas,ratings
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license:
+publisher: FactDen
+organization:
+issued_time:
+sources: []

--- a/core/SocialNetworks/Trip-com-Ctrip-Hotel-Reviews-Sample-Dataset.yml
+++ b/core/SocialNetworks/Trip-com-Ctrip-Hotel-Reviews-Sample-Dataset.yml
@@ -1,6 +1,6 @@
 ---
 title: Trip.com and Ctrip Hotel Reviews Sample Dataset (800 reviews)
-homepage: https://huggingface.co/datasets/fact-den/ctrip-trip-com-hotel-reviews-sample
+homepage: https://huggingface.co/datasets/fact-den/trip-com-and-ctrip-hotel-reviews-sample-2026
 category: SocialNetworks
 description: 800 hotel guest reviews from Trip.com and Ctrip (4 hotels) with sub-ratings, owner responses and English translations of Chinese reviews. CSV/JSON, also mirrored on Kaggle.
 version:

--- a/core/SocialNetworks/Trip-com-Ctrip-Hotel-Reviews-Sample-Dataset.yml
+++ b/core/SocialNetworks/Trip-com-Ctrip-Hotel-Reviews-Sample-Dataset.yml
@@ -1,0 +1,22 @@
+---
+title: Trip.com and Ctrip Hotel Reviews Sample Dataset (800 reviews)
+homepage: https://huggingface.co/datasets/fact-den/ctrip-trip-com-hotel-reviews-sample
+category: SocialNetworks
+description: 800 hotel guest reviews from Trip.com and Ctrip (4 hotels) with sub-ratings, owner responses and English translations of Chinese reviews. CSV/JSON, also mirrored on Kaggle.
+version:
+keywords: reviews,hotels,travel,ratings,chinese
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary:
+language: en,zh
+license:
+publisher: FactDen
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
Adds three free, public datasets (no signup required), all hosted on HuggingFace:

- **G2 Software Reviews Sample** (SocialNetworks) - 500 structured B2B software reviews across 5 team-collaboration tools: overall rating, six sub-ratings, structured pros/cons, switched-from competitor and reviewer context. https://huggingface.co/datasets/fact-den/g2-team-collaboration-reviews-sample
- **Trip.com & Ctrip Hotel Reviews Sample** (SocialNetworks) - 800 hotel guest reviews (4 hotels) with sub-ratings, owner responses and English translations of the Chinese reviews. https://huggingface.co/datasets/fact-den/trip-com-and-ctrip-hotel-reviews-sample-2026
- **Indeed Job Postings Sample** (Economics) - structured job postings with parsed numeric salaries, locations, job types, remote flags and benefits. https://huggingface.co/datasets/fact-den/indeed-job-postings-2026

Review datasets placed in SocialNetworks alongside the existing Skytrax air-travel reviews dataset; job postings in Economics. CSV/JSON formats.