### PR TITLE
Add US Vehicle Reliability (NHTSA complaints & recalls) under Transportation

### DIFF
--- a/core/Transportation/US-Vehicle-Reliability-NHTSA-ProblemsByVin.yml
+++ b/core/Transportation/US-Vehicle-Reliability-NHTSA-ProblemsByVin.yml
@@ -1,0 +1,23 @@
+---
+title: US Vehicle Reliability - NHTSA Owner Complaints & Recalls
+homepage: https://huggingface.co/ProblemsByVin
+category: Transportation
+description: Derived open datasets from the US National Highway Traffic Safety Administration (NHTSA) owner-complaint and recall record, model years 2005-2026. Includes failure-mileage quartiles, post-warranty failure patterns, verified recall gaps, engine and transmission complaint density, NHTSA defect investigations, and a per-vehicle reliability scorecard. Distributed as CSV.
+version: 1.0
+keywords: vehicles, automotive, NHTSA, vehicle reliability, recalls, owner complaints, failure analysis
+image:
+temporal: 2005-2026
+spatial: United States
+access_level: public
+copyrights:
+accrual_periodicity: weekly
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: ProblemsByVin
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
Adds ProblemsByVin's open NHTSA vehicle-reliability datasets under Transportation.

Free CSV downloads under CC BY 4.0, no login required, hosted on Hugging Face (https://huggingface.co/ProblemsByVin). Derived from the public US NHTSA owner-complaint and recall record (model years 2005-2026): failure-mileage quartiles, post-warranty failure patterns, verified recall gaps, engine/transmission complaint density, NHTSA defect investigations, and a per-vehicle reliability scorecard.

The `category` field matches the Transportation folder.