### PR TITLE
Add OpenWaterAtlas Spot-Climate-Species-Routes Dataset to EarthScience

### DIFF
--- a/core/EarthScience/OpenWaterAtlas.yml
+++ b/core/EarthScience/OpenWaterAtlas.yml
@@ -1,0 +1,31 @@
+---
+title: OpenWaterAtlas Spot-Climate-Species-Routes Dataset
+homepage: https://openwateratlas.com/en/datasets/
+category: EarthScience
+description: 2,928 named dive, kite, surf and freedive sites joined to 112,548 OBIS + GBIF marine species occurrences within 5 km of each site (with a family-level terrestrial-noise filter), per-spot 5-year daily climate aggregates (Open-Meteo + ERA5), and 34,876 OpenFlights direct routes. One citable bundle, versioned Zenodo DOI, mirrored on Kaggle and HuggingFace.
+version: 1.0.0
+keywords: ocean, marine biodiversity, dive sites, species occurrences, OBIS, GBIF, climate, coral bleaching, OpenFlights
+image:
+temporal: 2019-2024 daily climate aggregates
+spatial: global, point sites
+access_level: public
+copyrights: CC-BY 4.0
+accrual_periodicity: irregular
+specification:
+data_quality: true
+data_dictionary: https://openwateratlas.com/en/datasets/
+language: en
+license: CC-BY 4.0
+publisher:
+  - name: OpenWaterAtlas
+    web: https://openwateratlas.com
+organization:
+  - name: OpenWaterAtlas
+    web: https://openwateratlas.com
+issued_time: 2026.06
+sources:
+  - name: Zenodo
+    access_url: https://doi.org/10.5281/zenodo.20668393
+references:
+  - title: OpenWaterAtlas datasets landing page and methodology
+    reference: https://openwateratlas.com/en/datasets/


### PR DESCRIPTION
Adds a new EarthScience data entry (`core/EarthScience/OpenWaterAtlas.yml`).

Each of OBIS, GBIF, OpenFlights and Open-Meteo/ERA5 is already open individually, but the *join* — dive site ↔ 5-year daily climate ↔ marine species occurrences (≤5 km) ↔ direct-route graph — does not exist elsewhere as one citable file. 2,928 sites, 112,548 occurrences, 34,876 routes.

- License: CC-BY 4.0
- Direct download, no login/paywall: Zenodo DOI 10.5281/zenodo.20668393 (mirrored on Kaggle + HuggingFace)
- Landing page + methodology: https://openwateratlas.com/en/datasets/

Followed CONTRIBUTING.md — added a `.yml` under `core/EarthScience/` rather than editing the generated README.rst. Happy to adjust any fields.