### PR TITLE
Add TCGA and HEST Xenium virtual spatial transcriptomics datasets (Biology)

### DIFF
--- a/core/Biology/HEST-Xenium-virtual-spatial-transcriptomics.yml
+++ b/core/Biology/HEST-Xenium-virtual-spatial-transcriptomics.yml
@@ -27,5 +27,5 @@ sources:
   - name: Hugging Face
     access_url: https://huggingface.co/datasets/ratschlab/HEST_Xenium_virtual_spatial_transcriptomics
 references:
-  - title: DeepSpot-M: a multimodal foundation model for transcriptome-wide virtual spatial transcriptomics from histology
+  - title: "DeepSpot-M: a multimodal foundation model for transcriptome-wide virtual spatial transcriptomics from histology"
     reference: https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1

--- a/core/Biology/HEST-Xenium-virtual-spatial-transcriptomics.yml
+++ b/core/Biology/HEST-Xenium-virtual-spatial-transcriptomics.yml
@@ -1,0 +1,31 @@
+---
+title: HEST Xenium virtual spatial transcriptomics
+homepage: https://huggingface.co/datasets/ratschlab/HEST_Xenium_virtual_spatial_transcriptomics
+category: Biology
+description: Multimodal virtual single-cell spatial transcriptomics from DeepSpot-M on all 59 HEST-1k Xenium samples (H&E + expression + spatial coords + gene names). ~13.3M cells across 22 tissue types, transcriptome-wide. Gated on Hugging Face (CC-BY-NC-SA-4.0). Paper https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1 ; code https://github.com/ratschlab/DeepSpotM
+version:
+keywords: spatial transcriptomics, single-cell, histopathology, multimodal, Xenium, HEST, deep learning
+image:
+temporal:
+spatial:
+access_level: gated
+copyrights: https://huggingface.co/datasets/ratschlab/HEST_Xenium_virtual_spatial_transcriptomics
+accrual_periodicity:
+specification:
+data_quality:
+data_dictionary:
+language: en
+license: CC-BY-NC-SA-4.0
+publisher:
+  - name: ratschlab
+    web: https://github.com/ratschlab
+organization:
+  - name: Ratschlab
+    web: https://www.ratschlab.org/
+issued_time: 2026
+sources:
+  - name: Hugging Face
+    access_url: https://huggingface.co/datasets/ratschlab/HEST_Xenium_virtual_spatial_transcriptomics
+references:
+  - title: DeepSpot-M: a multimodal foundation model for transcriptome-wide virtual spatial transcriptomics from histology
+    reference: https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1

--- a/core/Biology/TCGA-virtual-spatial-transcriptomics-atlas.yml
+++ b/core/Biology/TCGA-virtual-spatial-transcriptomics-atlas.yml
@@ -27,5 +27,5 @@ sources:
   - name: Hugging Face
     access_url: https://huggingface.co/datasets/ratschlab/TCGA_virtual_spatial_transcriptomics_atlas
 references:
-  - title: DeepSpot-M: a multimodal foundation model for transcriptome-wide virtual spatial transcriptomics from histology
+  - title: "DeepSpot-M: a multimodal foundation model for transcriptome-wide virtual spatial transcriptomics from histology"
     reference: https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1

--- a/core/Biology/TCGA-virtual-spatial-transcriptomics-atlas.yml
+++ b/core/Biology/TCGA-virtual-spatial-transcriptomics-atlas.yml
@@ -1,0 +1,31 @@
+---
+title: TCGA virtual spatial transcriptomics atlas
+homepage: https://huggingface.co/datasets/ratschlab/TCGA_virtual_spatial_transcriptomics_atlas
+category: Biology
+description: Multimodal virtual spatial transcriptomics from DeepSpot-M on TCGA H&E (expression + spatial coords + gene names). 28,664 slides (17,372 FF + 11,292 FFPE), 10,865 patients, 32 cancers, 295.3M spots, transcriptome-wide (19,338 genes). Gated on Hugging Face (CC-BY-NC-SA-4.0). Paper https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1 ; code https://github.com/ratschlab/DeepSpotM
+version:
+keywords: spatial transcriptomics, histopathology, multimodal, TCGA, gene expression, deep learning
+image:
+temporal:
+spatial:
+access_level: gated
+copyrights: https://huggingface.co/datasets/ratschlab/TCGA_virtual_spatial_transcriptomics_atlas
+accrual_periodicity:
+specification:
+data_quality:
+data_dictionary:
+language: en
+license: CC-BY-NC-SA-4.0
+publisher:
+  - name: ratschlab
+    web: https://github.com/ratschlab
+organization:
+  - name: Ratschlab
+    web: https://www.ratschlab.org/
+issued_time: 2026
+sources:
+  - name: Hugging Face
+    access_url: https://huggingface.co/datasets/ratschlab/TCGA_virtual_spatial_transcriptomics_atlas
+references:
+  - title: DeepSpot-M: a multimodal foundation model for transcriptome-wide virtual spatial transcriptomics from histology
+    reference: https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1


### PR DESCRIPTION
## Summary
Add DeepSpot-M virtual spatial transcriptomics datasets under Biology — predicted transcriptome-wide ST from H&E (ratschlab). These feed into the auto-generated [awesome-public-datasets](https://github.com/awesomedata/awesome-public-datasets) list.

Happy to adjust placement/wording.

## Links
| Dataset | HF | Paper | Code |
|---|---|---|---|
| TCGA virtual spatial transcriptomics atlas | https://huggingface.co/datasets/ratschlab/TCGA_virtual_spatial_transcriptomics_atlas | https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1 | https://github.com/ratschlab/DeepSpotM |
| HEST Xenium virtual spatial transcriptomics | https://huggingface.co/datasets/ratschlab/HEST_Xenium_virtual_spatial_transcriptomics | https://www.medrxiv.org/content/10.64898/2026.06.19.26356060v1 | https://github.com/ratschlab/DeepSpotM |

## Notes
- Both are gated (CC-BY-NC-SA-4.0) on Hugging Face (HF gated access / license acceptance).
- Primary link is the HF dataset page; paper/code are DeepSpot-M.

Made with [Cursor](https://cursor.com)