### PR TITLE
Add AtlasPI (GIS)

### DIFF
--- a/core/GIS/AtlasPI.yml
+++ b/core/GIS/AtlasPI.yml
@@ -1,0 +1,31 @@
+---
+title: AtlasPI
+homepage: https://atlaspi.it
+category: GIS
+description: Historical geography REST API & MCP — 1000+ polities with real GeoJSON borders, events, dynastic chains, cited sources, 4500 BCE-2024
+version: 1.0
+keywords: historical, geojson, borders, api, digital-humanities
+image:
+temporal: 4500 BCE - 2024
+spatial: worldwide
+access_level: public
+copyrights:
+accrual_periodicity: irregular
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license: Apache-2.0
+publisher:
+  - name: AtlasPI
+    web: https://atlaspi.it
+organization:
+  - name:
+    web:
+issued_time: 2026.07
+sources:
+  - name: AtlasPI API docs
+    access_url: https://atlaspi.it/docs
+references:
+  - title: llms.txt
+    reference: https://atlaspi.it/llms.txt


### PR DESCRIPTION
Adds **AtlasPI** — an open (Apache-2.0) REST API + MCP server for historical geography: 1,000+ polities with real GeoJSON borders, events, dynastic succession chains, cited academic sources and per-record confidence scores, covering 4500 BCE to today.

- Live: https://atlaspi.it (no API key, CORS enabled)
- MCP server: PyPI `atlaspi-mcp` (34 tools), listed in the official MCP registry as `io.github.Soil911/atlaspi`
- Docs: https://atlaspi.it/docs · llms.txt: https://atlaspi.it/llms.txt

I'm the author/maintainer of the project.
