### PR TITLE
Add powerlifting datasets to Sports: OpenPowerlifting + derived strength percentiles

### DIFF
--- a/core/Sports/OpenPowerlifting.yml
+++ b/core/Sports/OpenPowerlifting.yml
@@ -1,0 +1,31 @@
+---
+title: OpenPowerlifting
+homepage: https://www.openpowerlifting.org/
+category: Sports
+description: Open archive of the world's powerlifting competition results — 3.9+ million meet entries covering squat, bench press and deadlift with lifter sex, age, bodyweight, equipment and federation. Full database downloadable as a single CSV, updated continuously by an open-source community project.
+version:
+keywords: powerlifting, strength sports, competition results, squat, bench press, deadlift
+image:
+temporal: 1964-present
+spatial: worldwide
+access_level: public
+copyrights:
+accrual_periodicity: continuous
+specification:
+data_quality: true
+data_dictionary: https://openpowerlifting.gitlab.io/opl-csv/bulk-csv-docs.html
+language: en
+license: CC0 1.0 (public domain)
+publisher:
+  - name: OpenPowerlifting
+    web: https://www.openpowerlifting.org/
+organization:
+  - name: OpenPowerlifting (open-source community project)
+    web: https://gitlab.com/openpowerlifting/opl-data
+issued_time:
+sources:
+  - name: OpenPowerlifting bulk data
+    access_url: https://data.openpowerlifting.org/
+references:
+  - title:
+    reference:

--- a/core/Sports/Powerlifting-Strength-Percentiles.yml
+++ b/core/Sports/Powerlifting-Strength-Percentiles.yml
@@ -1,0 +1,31 @@
+---
+title: Powerlifting Strength Percentiles by Sex, Age and Bodyweight
+homepage: https://github.com/arvidfcjarfalla-prog/liftgauge-strength-data
+category: Sports
+description: Pre-aggregated strength percentile, progression-trajectory and strength-by-age cubes derived from the OpenPowerlifting CC0 dataset — 8,500+ percentile cells (sex x lift x bodyweight class x single-year age x equipment) and a median-DOTS-by-age curve over 441,789 qualifying raw full-power entries. Ships the deterministic ETL scripts alongside the JSON outputs, with SHA-256 provenance back to the exact source CSV.
+version: 1.0
+keywords: powerlifting, strength standards, percentiles, aging, DOTS, OpenPowerlifting
+image:
+temporal: 1964-2026
+spatial: worldwide
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: true
+data_dictionary: https://github.com/arvidfcjarfalla-prog/liftgauge-strength-data#file-reference
+language: en
+license: CC0 1.0 (data), MIT (scripts)
+publisher:
+  - name: LiftGauge
+    web: https://liftgauge.com/strength-standards
+organization:
+  - name:
+    web:
+issued_time: 2026.07
+sources:
+  - name: GitHub repository (data + ETL)
+    access_url: https://github.com/arvidfcjarfalla-prog/liftgauge-strength-data
+references:
+  - title: Methodology writeup
+    reference: https://liftgauge.com/method


### PR DESCRIPTION
The Sports category currently has no strength-sports entry. This PR adds two:

**OpenPowerlifting** — the open archive of the world's powerlifting competition results: 3.9M+ meet entries, CC0/public domain, downloadable as a single CSV, continuously updated since 2014 by an open-source community (gitlab.com/openpowerlifting/opl-data). It is the de-facto canonical dataset of the sport and already widely used in analyses on Kaggle and elsewhere.

**Powerlifting Strength Percentiles by Sex, Age and Bodyweight** — pre-aggregated percentile/trajectory/age cubes derived from the OpenPowerlifting CSV, published with the deterministic ETL scripts and SHA-256 provenance back to the exact source snapshot. CC0 data / MIT scripts.

Transparency note: the second entry is my own derived-data repository (built on the first). If the maintainers prefer to keep only the primary OpenPowerlifting entry, I'm happy to drop the second — the first is the important gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)