### PR TITLE
Add Passport & Visa Photo Specifications dataset (CC BY 4.0)

### DIFF
--- a/core/Government/Passport-Visa-Photo-Specifications.yml
+++ b/core/Government/Passport-Visa-Photo-Specifications.yml
@@ -1,0 +1,22 @@
+---
+title: Passport & Visa Photo Specifications (21 documents, 15+ countries)
+homepage: https://compliantpassportphoto.com/specs.json
+category: Government
+description: Machine-readable photo specifications for passports, visas and ID documents across 15+ countries (US, UK, Canada, Schengen, India, China visa, and more). Each record carries photo dimensions, head-height and eye-position bands, background rules, digital file constraints, a source link to the official government requirement, and a last-verified date.
+version:
+keywords: passport,visa,photo,identity documents,government requirements,biometrics
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity: irregular
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license: CC BY 4.0
+publisher: Compliant Passport Photo
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
Adds a Government-category record for an open dataset of official passport, visa and ID photo specifications covering 21 documents across 15+ countries (US, UK, Canada, Schengen, India, China visa, India OCI, and others).

Each record includes photo dimensions, head-height and eye-position bands, background rules, and digital file constraints, with a citation link to the official government source and a last-verified date per document.

- Data: https://compliantpassportphoto.com/specs.json (JSON, CORS-open)
- License: CC BY 4.0
- Human-readable comparison: https://compliantpassportphoto.com/passport-photo-rules-compared

Disclosure: I maintain this dataset; it is published openly for reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)