### PR TITLE
Add Lithuania repeat-sales house price index (PSBKI)

### DIFF
--- a/core/Government/Lithuania-Repeat-Sales-House-Price-Index-PSBKI.yml
+++ b/core/Government/Lithuania-Repeat-Sales-House-Price-Index-PSBKI.yml
@@ -2,7 +2,7 @@
 title: Lithuania Repeat-Sales House Price Index (PSBKI)
 homepage: https://www.lb.lt/lt/pasikartojanciu-sandoriu-busto-kainu-indeksas
 category: Government
-description: Monthly repeat-sales apartment price indices (2015=100) and monthly and annual changes for Lithuania and the Vilnius, Kaunas, and Klaipeda city municipalities, published by the Bank of Lithuania. A versioned normalization provides direct CSV and JSON downloads, source field codes, checksums, and provenance.
+description: Monthly repeat-sales house price indices for dwellings in multi-dwelling buildings (2015=100), with monthly and annual changes for Lithuania and the Vilnius, Kaunas, and Klaipeda city municipalities, published by the Bank of Lithuania. A versioned normalization provides direct CSV and JSON downloads, source field codes, checksums, and provenance.
 version: 2026.06
 keywords: housing prices, repeat sales index, Lithuania, Vilnius, Kaunas, Klaipeda, PSBKI
 image:

--- a/core/Government/Lithuania-Repeat-Sales-House-Price-Index-PSBKI.yml
+++ b/core/Government/Lithuania-Repeat-Sales-House-Price-Index-PSBKI.yml
@@ -1,0 +1,33 @@
+---
+title: Lithuania Repeat-Sales House Price Index (PSBKI)
+homepage: https://www.lb.lt/lt/pasikartojanciu-sandoriu-busto-kainu-indeksas
+category: Government
+description: Monthly repeat-sales apartment price indices (2015=100) and monthly and annual changes for Lithuania and the Vilnius, Kaunas, and Klaipeda city municipalities, published by the Bank of Lithuania. A versioned normalization provides direct CSV and JSON downloads, source field codes, checksums, and provenance.
+version: 2026.06
+keywords: housing prices, repeat sales index, Lithuania, Vilnius, Kaunas, Klaipeda, PSBKI
+image:
+temporal: 2006-01/2026-06
+spatial: Lithuania; Vilnius, Kaunas, and Klaipeda city municipalities
+access_level: public
+copyrights: Bank of Lithuania information use terms
+accrual_periodicity: monthly
+specification: https://github.com/matas-star/lt-real-estate-prices/releases/download/v2026.06/datapackage.json
+data_quality: false
+data_dictionary: https://github.com/matas-star/lt-real-estate-prices/releases/download/v2026.06/datapackage.json
+language: lt, en
+license: https://www.lb.lt/lt/informacijos-naudojimo-salygos
+publisher:
+  - name: Bank of Lithuania
+    web: https://www.lb.lt/
+organization:
+  - name: Bank of Lithuania
+    web: https://www.lb.lt/
+issued_time: 2026-07-13
+sources:
+  - name: Official Bank of Lithuania CSV export
+    access_url: https://www.lb.lt/lt/m_statistika/t-pasikartojanciu-sandoriu-busto-kainu-indeksai/?export=csv
+references:
+  - title: Versioned normalized release with CSV, JSON, checksums, and provenance
+    reference: https://github.com/matas-star/lt-real-estate-prices/releases/tag/v2026.06
+  - title: Immutable Software Heritage snapshot of the normalization repository
+    reference: https://archive.softwareheritage.org/swh:1:snp:200fae1b0c5049d631626d72c3df1fdc9b4a3cb6/


### PR DESCRIPTION
## Dataset

This adds the Bank of Lithuania's monthly repeat-sales house price index for dwellings in multi-dwelling buildings, covering Lithuania and its three largest city municipalities.

Why it may fit the catalog:

- it is an official public dataset with no login or purchase requirement;
- it provides a long monthly time series beginning in 2006;
- it covers a national housing market that is uncommon in English-language public-data catalogs;
- the official source and its information-use terms are linked directly.

The entry also links a versioned normalization with direct CSV/JSON assets, checksums, field-level provenance, and an immutable Software Heritage snapshot. I maintain that normalization repository, so I am disclosing that relationship explicitly. The Bank of Lithuania remains identified as both publisher and primary source.

## Validation

- [x] One YAML entry only
- [x] Official source is the homepage
- [x] Category matches `core/Government`
- [x] Local `tests/validate.py` passes
