### PR TITLE
Add US FAA A&P Mechanics and Repair Stations dataset under Transportation

### DIFF
--- a/core/Transportation/US-FAA-AP-Mechanics-and-Repair-Stations-by-State.yml
+++ b/core/Transportation/US-FAA-AP-Mechanics-and-Repair-Stations-by-State.yml
@@ -1,0 +1,31 @@
+---
+title: US FAA A&P Mechanics and Repair Stations by State
+homepage: https://apnearme.com/data
+category: Transportation
+description: State-level counts of all 233,886 FAA-certificated Airframe & Powerplant (A&P) mechanics and Inspection Authorization holders, all 3,965 FAA Part 145 repair stations with ratings and geocoded coordinates, and A&P mechanics per 100 based aircraft (FAA TAF FY2024) for the 50 US states + DC. Cleaned and consolidated from public FAA source data; direct CSV/JSON downloads, no login.
+version: 2026-07
+keywords: aviation, FAA, aircraft maintenance, A&P mechanic, Part 145 repair station, based aircraft, United States
+image:
+temporal: 2026
+spatial: United States (50 states + DC)
+access_level: public
+copyrights: Public domain (US government source data, 17 U.S.C. 105); compilation CC0 1.0
+accrual_periodicity: irregular (refreshed with each FAA data pull, roughly monthly)
+specification:
+data_quality: true
+data_dictionary: https://apnearme.com/data
+language: en
+license: CC0 1.0
+publisher:
+  - name: APNearMe
+    web: https://apnearme.com
+organization:
+  - name: APNearMe
+    web: https://apnearme.com
+issued_time: 2026.06
+sources:
+  - name: Federal Aviation Administration
+    access_url: https://www.faa.gov/licenses_certificates/airmen_certification/releasable_airmen_download
+references:
+  - title: The State of U.S. Aircraft Maintenance (dataset hub and methodology)
+    reference: https://apnearme.com/data


### PR DESCRIPTION
Adds a state-level US aviation-maintenance dataset under Transportation.

What it is: counts of all 233,886 FAA-certificated A&P mechanics and IA holders,
all 3,965 FAA Part 145 repair stations (with ratings and geocoded coordinates),
and mechanics-per-100-based-aircraft ratios for the 50 states + DC, consolidated
from three public FAA sources (Airmen Certification DB, Part 145 repair station
DB, Terminal Area Forecast).

Access: direct CSV/JSON downloads at https://apnearme.com/data, no login, no
paywall. License: source data is US-government public domain (17 U.S.C. 105);
the compilation is CC0 1.0. Methodology and data dictionary are on the same page.

Passes the three required fields (title/homepage/category); category matches the
core/Transportation folder.