### PR TITLE
Add: The 250 Most-Funded Startups of 2026 (Finance)

### DIFF
--- a/core/Finance/Top-Funded-Startups-2026.yml
+++ b/core/Finance/Top-Funded-Startups-2026.yml
@@ -1,0 +1,30 @@
+---
+title: The 250 Most-Funded Startups of 2026
+homepage: https://indexed.vc/reports/top-funded-startups-2026
+category: Finance
+description: The 250 private startups that raised the most venture capital in calendar year 2026, ranked by total disclosed new funding, with lead investor, largest-round date, country, and sector for each company. Source-verified against primary announcements (Reuters, Bloomberg, TechCrunch) with duplicate rounds de-duplicated and valuations-mistaken-for-raises corrected. Copy-as-Markdown export on the page.
+version: '1.0'
+keywords:
+  - venture capital
+  - startup funding
+  - 2026
+  - fundraising
+  - private markets
+  - investors
+image:
+temporal: '2026'
+spatial: Global
+access_level: public
+copyrights: Indexed (indexed.vc)
+accrual_periodicity: annually
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license: CC-BY-4.0
+publisher: Indexed
+organization: Indexed
+issued_time: '2026-07-22'
+sources:
+  - name: Indexed
+    web: https://indexed.vc


### PR DESCRIPTION
Adds **The 250 Most-Funded Startups of 2026** to the Finance category.

- **Homepage:** https://indexed.vc/reports/top-funded-startups-2026
- **License:** CC BY 4.0 (free to use with attribution)
- **Access:** public, no login or key required
- **Format:** ranked table on-page + copy-as-Markdown export

**What it is:** the 250 private startups that raised the most venture capital in calendar year 2026, ranked by total disclosed new funding, each with lead investor, largest-round date, country, and sector.

**Methodology / quality:** new primary equity funding only (grants, debt, secondaries, IPOs, and M&A excluded); active private companies only. Every entry was cross-checked against primary sources (Reuters, Bloomberg, TechCrunch), with duplicate rounds de-duplicated and valuations-mistaken-for-raises corrected. Methodology and license are documented on the page.
