### PR TITLE
Add Russian and Belarusian matchmaking demographics dataset (SocialSciences)

### DIFF
--- a/core/SocialSciences/Russian-Belarusian-Matchmaking.yml
+++ b/core/SocialSciences/Russian-Belarusian-Matchmaking.yml
@@ -1,0 +1,35 @@
+---
+title: Russian and Belarusian Women in International Matchmaking (2026)
+homepage: https://github.com/lovevalentin-droid/russian-women-matchmaking-dataset
+category: SocialSciences
+description: Aggregated, anonymised demographic profile of 686 women registered with a Moscow-based international matchmaking agency, compiled 1 July 2026. Covers age distribution, education level, occupation, language proficiency, marital status, children, partner age range sought and nationality. Every percentage is computed only on the profiles that completed the relevant field, and the reference sample size is stated per indicator. Counters the common assumption about who seeks international marriage: mean age 42.7, 96 percent hold a higher-education degree, manager and teacher are the most common occupations. Published as CSV and JSON with methodology and stated limits, including that the sample is a subset of the agency base and that Belarus is under-represented.
+version: 1.0
+keywords: demography, sociology, international marriage, migration, gender, Russia, Belarus, family formation, survey data
+image:
+temporal: 2026
+spatial: Russia, Belarus
+access_level: public
+copyrights: CC BY 4.0
+accrual_periodicity: irregular
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: Valentin Love
+    web: https://www.valentin.love/
+organization:
+  - name: Valentin Love
+    web: https://www.valentin.love/
+issued_time: 2026.07
+sources:
+  - name: Aggregated indicators (JSON)
+    access_url: https://github.com/lovevalentin-droid/russian-women-matchmaking-dataset/blob/main/data/observatoire-valentin-love-2026.json
+  - name: Aggregated indicators (CSV)
+    access_url: https://github.com/lovevalentin-droid/russian-women-matchmaking-dataset/blob/main/data/observatoire-valentin-love-2026.csv
+references:
+  - title: Observatory 2026, human-readable companion (EN)
+    reference: https://www.valentin.love/en/observatoire-rencontre-internationale
+  - title: Observatoire 2026, version francaise
+    reference: https://www.valentin.love/observatoire-rencontre-internationale

--- a/core/SocialSciences/Russian-Belarusian-Matchmaking.yml
+++ b/core/SocialSciences/Russian-Belarusian-Matchmaking.yml
@@ -2,8 +2,7 @@
 title: Russian and Belarusian Women in International Matchmaking (2026)
 homepage: https://github.com/lovevalentin-droid/russian-women-matchmaking-dataset
 category: SocialSciences
-description: >
-	Aggregated, anonymised demographic profile of 686 women registered with a Moscow-based international matchmaking agency, compiled 1 July 2026. Covers age distribution, education level, occupation, language proficiency,     	marital status, children, partner age range sought and nationality. Every percentage is computed only on the profiles that completed the relevant field, and the reference sample size is stated per indicator. Counters the 	common assumption about who seeks international marriage: mean age 42.7, 96 percent hold a higher-education degree, manager and teacher are the most common occupations. Published as CSV and JSON with methodology and 		stated limits, including that the sample is a subset of the agency base and that Belarus is under-represented.
+description: Aggregated, anonymised demographic profile of 686 women registered with a Moscow-based international matchmaking agency, compiled 1 July 2026. Covers age distribution, education level, occupation, language proficiency, marital status, children, partner age range sought and nationality. Every percentage is computed only on the profiles that completed the relevant field, and the reference sample size is stated per indicator. Counters the common assumption about who seeks international marriage. Mean age 42.7, 96 percent hold a higher-education degree, manager and teacher are the most common occupations. Published as CSV and JSON with methodology and stated limits, including that the sample is a subset of the agency base and that Belarus is under-represented.
 version: 1.0
 keywords: demography, sociology, international marriage, migration, gender, Russia, Belarus, family formation, survey data
 image:

--- a/core/SocialSciences/Russian-Belarusian-Matchmaking.yml
+++ b/core/SocialSciences/Russian-Belarusian-Matchmaking.yml
@@ -2,7 +2,8 @@
 title: Russian and Belarusian Women in International Matchmaking (2026)
 homepage: https://github.com/lovevalentin-droid/russian-women-matchmaking-dataset
 category: SocialSciences
-description: Aggregated, anonymised demographic profile of 686 women registered with a Moscow-based international matchmaking agency, compiled 1 July 2026. Covers age distribution, education level, occupation, language proficiency, marital status, children, partner age range sought and nationality. Every percentage is computed only on the profiles that completed the relevant field, and the reference sample size is stated per indicator. Counters the common assumption about who seeks international marriage: mean age 42.7, 96 percent hold a higher-education degree, manager and teacher are the most common occupations. Published as CSV and JSON with methodology and stated limits, including that the sample is a subset of the agency base and that Belarus is under-represented.
+description: >
+	Aggregated, anonymised demographic profile of 686 women registered with a Moscow-based international matchmaking agency, compiled 1 July 2026. Covers age distribution, education level, occupation, language proficiency,     	marital status, children, partner age range sought and nationality. Every percentage is computed only on the profiles that completed the relevant field, and the reference sample size is stated per indicator. Counters the 	common assumption about who seeks international marriage: mean age 42.7, 96 percent hold a higher-education degree, manager and teacher are the most common occupations. Published as CSV and JSON with methodology and 		stated limits, including that the sample is a subset of the agency base and that Belarus is under-represented.
 version: 1.0
 keywords: demography, sociology, international marriage, migration, gender, Russia, Belarus, family formation, survey data
 image:


### PR DESCRIPTION
Adds an open dataset under **SocialSciences**: the aggregated, anonymised demographic profile of 686 women registered with a Moscow-based international matchmaking agency, compiled on 1 July 2026.

**Why it may be useful here.** Public discussion of international marriage runs largely on assumption. This is one of the few openly licensed datasets describing who actually seeks a foreign partner from Russia and Belarus: mean age 42.7, 96% holding a higher-education degree, manager and teacher as the two most common occupations, and a stated partner age band of 38 to 52.

**On rigour.** Every percentage is computed only on the profiles that completed the relevant field, and the reference sample size (`n_base`) is published per indicator rather than implied. The nationality tail is grouped rather than detailed, to stay away from identifiability. The README states the limits plainly: the sample is a subset of the agency base and not its entirety, Belarus is under-represented, fields are self-declared, and no success rate is published.

Files are CSV and JSON, CC BY 4.0, mirrored on Kaggle. Same submitter as #432 (Romance Scam Statistics), which was merged in June.
