### PR TITLE
Add Dealaka US Sign-Up Bonuses (Finance)

### DIFF
--- a/core/Finance/Dealaka-Sign-Up-Bonuses.yml
+++ b/core/Finance/Dealaka-Sign-Up-Bonuses.yml
@@ -1,0 +1,30 @@
+---
+title: Dealaka US Sign-Up Bonuses
+homepage: https://dealaka.com/data
+category: Finance
+description: Every US bank, credit card, brokerage, app, travel-loyalty and crypto sign-up bonus, with each figure verified against the institution's own published terms and carrying the date it was last checked. 260 offers across 146 institutions. Columns cover the bonus figure and its unit, the dollar requirement needed to unlock it, fee, keep and clawback period, payout timing, state footprint, hard-pull and ChexSystems posture, governing rules, and the source URL. CSV and JSON, no login or key, CORS enabled, regenerated from the live catalogue. Two caveats for analysis. The amount field records the FLOOR of a published range rather than the advertised ceiling, and the three units (cash, points, miles) must never be summed together. No affiliate placement. CC BY 4.0.
+version: 1.0
+keywords: sign-up bonus, bank bonus, credit card bonus, brokerage bonus, personal finance, promotions, banking, consumer finance.
+image:
+temporal: 2026-07-11/..
+spatial: United States
+access_level: public
+copyrights:
+accrual_periodicity: continuous
+specification:
+data_quality: false
+data_dictionary: https://dealaka.com/data
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: Dealaka
+    web: https://dealaka.com
+organization:
+  - name: Dealaka
+    web: https://dealaka.com
+issued_time: 2026
+sources:
+  - name: CSV
+    access_url: https://dealaka.com/data/offers.csv
+  - name: JSON
+    access_url: https://dealaka.com/data/offers.json


### PR DESCRIPTION
Adds `core/Finance/Dealaka-Sign-Up-Bonuses.yml`.

**What it is:** every US bank, credit card, brokerage, app, travel-loyalty and crypto sign-up bonus, with each figure verified against the institution's own published terms and carrying the date it was last checked. Currently 260 offers across 146 institutions.

**Access:** CSV and JSON, no login or API key, CORS enabled, regenerated from the live catalogue.

- CSV: https://dealaka.com/data/offers.csv
- JSON: https://dealaka.com/data/offers.json
- Documentation and column dictionary: https://dealaka.com/data

**Licence:** CC BY 4.0 on the structured records.

**Fields include** the bonus figure and its unit, the dollar requirement needed to unlock it, fee, keep/clawback period, payout timing, state footprint, hard-pull and ChexSystems posture, governing rules, and the source URL for each entry.

Two caveats written into the description because they are the errors a consumer would otherwise make: the `amount` field records the **floor** of a published range rather than the advertised ceiling, and the three units (cash, points, miles) must never be summed together.

Happy to adjust the description, keywords or category if anything doesn't fit the collection's conventions.