### PR TITLE
Add Loa U.S. healthcare pricing data

### DIFF
--- a/core/Healthcare/Loa-U.S.-Healthcare-Price-Transparency.yml
+++ b/core/Healthcare/Loa-U.S.-Healthcare-Price-Transparency.yml
@@ -2,8 +2,8 @@
 title: Loa U.S. Healthcare Price Transparency Dataset
 homepage: https://www.loacare.com/methodology
 category: Healthcare
-description: Source-labeled U.S. healthcare pricing data and a public JSON API covering 207,000+ provider profiles, 4,700+ hospital profiles, 116,000+ current hospital price rows, and CPT/HCPCS procedure comparisons. Responses include source, provenance, confidence, and caveat fields.
-version: "2026.07"
+description: Source-labeled U.S. healthcare pricing data, a public JSON API, and a downloadable aggregate CSV covering 207,000+ provider profiles, 4,700+ hospital profiles, 116,000+ current hospital price rows, and 964 procedure-city benchmarks. Responses include source, provenance, confidence, and caveat fields.
+version: "2026-07-29"
 keywords: healthcare prices, hospital price transparency, medical costs, CPT, HCPCS, providers, hospitals, machine-readable files, API
 image:
 temporal: 2021-present
@@ -22,8 +22,10 @@ publisher:
 organization:
   - name: Loa
     web: https://www.loacare.com
-issued_time: "2026.07"
+issued_time: "2026-07-29"
 sources:
+  - name: Aggregate procedure-city benchmark CSV
+    access_url: https://www.loacare.com/datasets/loa-us-healthcare-price-benchmarks.csv
   - name: Public healthcare entity search example
     access_url: https://www.loacare.com/api/v1/entities/search?q=rainforest&limit=1
   - name: Public healthcare price guides

--- a/core/Healthcare/Loa-U.S.-Healthcare-Price-Transparency.yml
+++ b/core/Healthcare/Loa-U.S.-Healthcare-Price-Transparency.yml
@@ -1,0 +1,35 @@
+---
+title: Loa U.S. Healthcare Price Transparency Dataset
+homepage: https://www.loacare.com/methodology
+category: Healthcare
+description: Source-labeled U.S. healthcare pricing data and a public JSON API covering 207,000+ provider profiles, 4,700+ hospital profiles, 116,000+ current hospital price rows, and CPT/HCPCS procedure comparisons. Responses include source, provenance, confidence, and caveat fields.
+version: "2026.07"
+keywords: healthcare prices, hospital price transparency, medical costs, CPT, HCPCS, providers, hospitals, machine-readable files, API
+image:
+temporal: 2021-present
+spatial: United States
+access_level: public
+copyrights: Data use is governed by the Loa Terms of Service; upstream records remain subject to their source terms.
+accrual_periodicity: continuous
+specification: https://www.loacare.com/api/v1/openapi.json
+data_quality: true
+data_dictionary: https://www.loacare.com/api/v1/openapi.json
+language: en
+license: https://www.loacare.com/terms
+publisher:
+  - name: Loa
+    web: https://www.loacare.com
+organization:
+  - name: Loa
+    web: https://www.loacare.com
+issued_time: "2026.07"
+sources:
+  - name: Public healthcare entity search example
+    access_url: https://www.loacare.com/api/v1/entities/search?q=rainforest&limit=1
+  - name: Public healthcare price guides
+    access_url: https://www.loacare.com/prices
+references:
+  - title: Data methodology, coverage, and provenance
+    reference: https://www.loacare.com/methodology
+  - title: OpenAPI 3.1 contract
+    reference: https://www.loacare.com/api/v1/openapi.json


### PR DESCRIPTION
Adds the Loa U.S. Healthcare Price Transparency Dataset to Healthcare.

The entry documents public, no-login access to source-labeled U.S. provider, hospital, and price data, with the canonical methodology page, OpenAPI 3.1 contract, direct JSON example, access terms, scale, provenance, and a direct aggregate CSV download.

The 2026-07-29 CSV contains 964 procedure-city benchmark rows across 30 procedures, 77 locations, and 38 states. It contains aggregate, non-PHI data; use remains governed by Loa's terms, and no open-data redistribution license is claimed.

Validation:
- Full `tests/testing.sh` pass
- Entry parses with the repository test requirements
- Methodology, CSV, OpenAPI contract, public JSON example, price catalog, and terms all return HTTP 200
- CSV row count, content length, and source-page links were validated against production
