### PR TITLE
Add OpenCard DB under Finance

### DIFF
--- a/core/Finance/OpenCard-DB.yml
+++ b/core/Finance/OpenCard-DB.yml
@@ -1,0 +1,32 @@
+---
+title: OpenCard DB
+homepage: https://github.com/thedavidweng/opencard-db
+category: Finance
+description: Community-maintained open dataset of credit card product metadata covering 189 cards across the United States, Canada, and China. Each record covers issuer, network, network tier, annual fee, FX fee, APR ranges, rewards structure, signup bonus, benefits, and source citations. Published as one JSON file per card validated against a JSON Schema, with bulk exports in JSON, CSV, and YAML served from a CDN. No login, no API key, no rate limits on the CDN path. Data licensed CC BY 4.0.
+version: 1.0
+keywords: credit cards, card products, issuer, network, Visa, Mastercard, American Express, UnionPay, rewards, annual fee, benefits, finance.
+image:
+temporal:
+spatial: US, CA, CN
+access_level: public
+copyrights:
+accrual_periodicity: as-needed
+specification:
+data_quality: true
+data_dictionary: https://github.com/thedavidweng/opencard-db/blob/main/schema.json
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: OpenCard DB
+    web: https://github.com/thedavidweng/opencard-db
+organization:
+  - name: OpenCard DB
+    web: https://github.com/thedavidweng/opencard-db
+issued_time: 2025
+sources:
+  - name: JSON (all cards)
+    access_url: https://cdn.jsdelivr.net/gh/thedavidweng/opencard-db@main/exports/cards-all.json
+  - name: CSV
+    access_url: https://cdn.jsdelivr.net/gh/thedavidweng/opencard-db@main/exports/cards.csv
+  - name: YAML
+    access_url: https://cdn.jsdelivr.net/gh/thedavidweng/opencard-db@main/exports/cards.yaml

--- a/core/Finance/OpenCard-DB.yml
+++ b/core/Finance/OpenCard-DB.yml
@@ -3,7 +3,7 @@ title: OpenCard DB
 homepage: https://github.com/thedavidweng/opencard-db
 category: Finance
 description: Community-maintained open dataset of credit card product metadata covering 189 cards across the United States, Canada, and China. Each record covers issuer, network, network tier, annual fee, FX fee, APR ranges, rewards structure, signup bonus, benefits, and source citations. Published as one JSON file per card validated against a JSON Schema, with bulk exports in JSON, CSV, and YAML served from a CDN. No login, no API key, no rate limits on the CDN path. Data licensed CC BY 4.0.
-version: 1.0
+version: 0.3.0
 keywords: credit cards, card products, issuer, network, Visa, Mastercard, American Express, UnionPay, rewards, annual fee, benefits, finance.
 image:
 temporal:
@@ -22,7 +22,7 @@ publisher:
 organization:
   - name: OpenCard DB
     web: https://github.com/thedavidweng/opencard-db
-issued_time: 2025
+issued_time: 2026.07
 sources:
   - name: JSON (all cards)
     access_url: https://cdn.jsdelivr.net/gh/thedavidweng/opencard-db@main/exports/cards-all.json


### PR DESCRIPTION
Adds OpenCard DB, a community-maintained open dataset of credit card product metadata (189 cards across the US, Canada, and China).

- **Directly downloadable**: per-card JSON and bulk JSON/CSV/YAML exports served from jsDelivr CDN, no login or paywall.
- **Domain value**: structured metadata on issuer, network, network tier, fees, FX, APR, rewards, signup bonus, and benefits, with source citations per card. Validated against a JSON Schema and updated via pull requests.
- **License**: data CC BY 4.0, code MIT.
- **No ads / no spam**: community project, no commercial promotion.

Modeled on the existing `Chargeback-Reason-Codes.yml` entry (same shape: open card-network reference data, CSV/JSON, CC BY 4.0).