### PR TITLE
Add Anti-Bot Adoption Index dataset (ComputerNetworks)

### DIFF
--- a/core/ComputerNetworks/Anti-Bot-Adoption-Index.yml
+++ b/core/ComputerNetworks/Anti-Bot-Adoption-Index.yml
@@ -1,0 +1,33 @@
+---
+title: 'Anti-Bot Adoption Index: WAF/anti-bot census of the top 1M domains'
+homepage: https://crawlora.net/anti-bot-index
+category: ComputerNetworks
+description: An anti-bot and WAF adoption census of the Tranco top 1,000,000 domains, probed for managed bot-management, CAPTCHA, WAF, and access-control vendors. Finds 53.5% of the 818,614 reachable domains run a managed anti-bot/WAF vendor, with Cloudflare alone covering 45%, and breaks down adoption by vendor, protection kind, CAPTCHA presence, and rank gradient.
+version: 1.0.0
+keywords: anti-bot, waf, bot management, captcha, cloudflare, web scraping, internet measurement, tranco
+image:
+temporal: 2026
+spatial: Worldwide
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: true
+data_dictionary: https://github.com/Crawlora-org/anti-bot-adoption-index-data#readme
+language: en
+license: CC BY 4.0
+publisher:
+- name: Crawlora
+  web: https://crawlora.net
+organization:
+- name: Crawlora
+  web: https://crawlora.net
+issued_time: 2026
+sources:
+- name: Dataset repository (top1m.jsonl.gz, ~1M rows)
+  access_url: https://github.com/Crawlora-org/anti-bot-adoption-index-data
+- name: Interactive study page
+  access_url: https://crawlora.net/anti-bot-index
+references:
+- title: Methodology
+  reference: https://crawlora.net/anti-bot-index/methodology


### PR DESCRIPTION
Adds a new dataset entry under `core/ComputerNetworks/`, following the same
format as the existing `AI-Crawler-Blocking-Index.yml` and `Dead-Web-Index.yml`
entries from the same publisher.

**Anti-Bot Adoption Index** — a WAF/anti-bot adoption census of the Tranco
top-1,000,000 domains, probing for managed bot-management, CAPTCHA, WAF, and
access-control vendors. 53.5% of the 818,614 reachable domains run a managed
anti-bot/WAF vendor, with Cloudflare covering 45% alone; breaks down adoption
by vendor, protection kind, CAPTCHA presence, and rank gradient.

- Public dataset repo (CC BY 4.0): https://github.com/Crawlora-org/anti-bot-adoption-index-data
- Interactive study page: https://crawlora.net/anti-bot-index
- Methodology: https://crawlora.net/anti-bot-index/methodology

Validated locally against `tests/validate.py` (title/homepage/category present,
category matches folder).