### PR TITLE
Add US H-1B / LCA Open Data under Economics

### DIFF
--- a/core/Economics/US-H-1B-LCA-Open-Data.yml
+++ b/core/Economics/US-H-1B-LCA-Open-Data.yml
@@ -1,0 +1,33 @@
+---
+title: US H-1B / LCA Open Data (Cleaned)
+homepage: https://h1b.report
+category: Economics
+description: Cleaned aggregate tables derived from US Department of Labor (OFLC) Labor Condition Application (LCA) disclosures, the public wage-and-worksite filings behind every H-1B, H-1B1, and E-3 hire. Covers about 9.3 million filings, 152,000+ canonical employers, and 782 occupations across FY2010-FY2026, with employer name variants reconciled into canonical organizations, job titles mapped to BLS SOC codes, and wages normalized to annual USD.
+version: 1.0
+keywords: h1b, labor condition application, immigration, wages, prevailing wage, employment, department of labor, visa, united states
+image:
+temporal: 2010-2026
+spatial: United States
+access_level: public
+copyrights: CC BY 4.0
+accrual_periodicity: quarterly
+specification:
+data_quality: true
+data_dictionary: https://h1b.report/methodology
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: h1b.report
+    web: https://h1b.report
+organization:
+  - name: h1b.report
+    web: https://h1b.report
+issued_time: 2026.07
+sources:
+  - name: H-1B / LCA aggregate tables (CSV)
+    access_url: https://www.kaggle.com/datasets/serhiiporotikov/us-h-1b-lca-data-cleaned-fy2010-fy2026
+  - name: Interactive database
+    access_url: https://h1b.report
+references:
+  - title: Methodology - h1b.report
+    reference: https://h1b.report/methodology

--- a/core/Economics/US-H-1B-LCA-Open-Data.yml
+++ b/core/Economics/US-H-1B-LCA-Open-Data.yml
@@ -1,6 +1,6 @@
 ---
 title: US H-1B / LCA Open Data (Cleaned)
-homepage: https://h1b.report
+homepage: https://www.kaggle.com/datasets/serhiiporotikov/us-h-1b-lca-data-cleaned-fy2010-fy2026
 category: Economics
 description: Cleaned aggregate tables derived from US Department of Labor (OFLC) Labor Condition Application (LCA) disclosures, the public wage-and-worksite filings behind every H-1B, H-1B1, and E-3 hire. Covers about 9.3 million filings, 152,000+ canonical employers, and 782 occupations across FY2010-FY2026, with employer name variants reconciled into canonical organizations, job titles mapped to BLS SOC codes, and wages normalized to annual USD.
 version: 1.0

--- a/core/Economics/US-H-1B-LCA-Open-Data.yml
+++ b/core/Economics/US-H-1B-LCA-Open-Data.yml
@@ -1,6 +1,6 @@
 ---
 title: US H-1B / LCA Open Data (Cleaned)
-homepage: https://www.kaggle.com/datasets/serhiiporotikov/us-h-1b-lca-data-cleaned-fy2010-fy2026
+homepage: https://h1b.report/open-data
 category: Economics
 description: Cleaned aggregate tables derived from US Department of Labor (OFLC) Labor Condition Application (LCA) disclosures, the public wage-and-worksite filings behind every H-1B, H-1B1, and E-3 hire. Covers about 9.3 million filings, 152,000+ canonical employers, and 782 occupations across FY2010-FY2026, with employer name variants reconciled into canonical organizations, job titles mapped to BLS SOC codes, and wages normalized to annual USD.
 version: 1.0


### PR DESCRIPTION
Adds an aggregate, openly-licensed (CC BY 4.0) dataset under Economics, derived from US Department of Labor LCA disclosures (the public wage/worksite filings behind H-1B, H-1B1, and E-3 hiring).

- ~9.3M filings, 152,000+ canonical employers, 782 occupations, FY2010-FY2026
- - Employer name variants reconciled, job titles mapped to BLS SOC codes, wages normalized to annual USD; small cells suppressed
- - New file: core/Economics/US-H-1B-LCA-Open-Data.yml
- - Homepage: https://h1b.report  |  Methodology: https://h1b.report/methodology  |  CSV tables on Kaggle