### PR TITLE
Add DNA Chip Coverage under Biology

### DIFF
--- a/core/Biology/DNA-Chip-Coverage.yml
+++ b/core/Biology/DNA-Chip-Coverage.yml
@@ -1,0 +1,24 @@
+---
+title: DNA Chip Coverage
+homepage: https://github.com/AndreySoloviev/dna-chip-coverage
+category: Biology
+description: Which SNP markers are present on consumer DNA genotyping arrays. 70 clinically discussed markers checked against the 5 published Illumina arrays that consumer chips are built on, plus 9 consumer products, giving 980 rows of marker x platform -> present / absent / unknown. Built only from public Illumina array manifests and dbSNP coordinates, with a dependency-free Python script that regenerates the table from those sources. Presence is resolved by genomic coordinate rather than by rsID string, because manifests rename probes. Distributed as CSV, with a companion analysis of 15 cases where coverage changes what a raw data file can support.
+version: 1.0
+keywords: SNP, genotyping array, microarray, consumer genomics, direct-to-consumer, DNA raw data, Illumina, dbSNP, marker coverage, pharmacogenomics
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: false
+data_dictionary: https://github.com/AndreySoloviev/dna-chip-coverage#reading-coveragecsv
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: Andrey Soloviev
+    web: https://github.com/AndreySoloviev
+organization:
+issued_time: 2026.07
+sources: []


### PR DESCRIPTION
Adds `core/Biology/DNA-Chip-Coverage.yml`. Local `tests/validate.py` passes.

**What it is:** a table of `SNP marker × consumer DNA genotyping array → present / absent / unknown`. 70 clinically discussed markers checked against the 5 published Illumina arrays that consumer chips are built on, plus 9 consumer products — 980 rows, distributed as CSV.

**Where the data comes from:** public Illumina array manifests and dbSNP coordinates, nothing else. `scripts/build.py` (Python 3.9+, standard library only, no dependencies) regenerates the table from those sources from scratch, and `SOURCES.md` gives a retrieval date for every source.

**Why it's useful:** a consumer DNA raw-data file contains only the markers its array happened to assay, and the file itself doesn't say which those are — so a tool reading it can report a result for a marker that was never measured. Worked example: an APOE ε genotype needs both `rs429358` and `rs7412`; all five arrays carry `rs7412`, exactly one carries `rs429358`. The dataset makes that checkable per marker.

One methodological detail that matters for reuse: presence is resolved by **genomic coordinate**, not by matching the rsID string, because manifests rename probes — `rs9923231` appears as `rs9923231`, `seq-rs9923231`, and `chr16-31107689:rs9923231-CT` across the five arrays. A literal rsID search reports it missing on three of five when it is on all five.

**Against the quality criteria in CONTRIBUTING:**
- *Uncommon to obtain legally in the open community* — array manifests are public but large and unwieldy; there's no published per-marker coverage table to query.
- *Downloadable directly* — plain CSV in a public repo, no login, no purchase, no registration.
- *No promotion* — the dataset is maintained by a company that reads these files, and this is stated openly in the README, but the dataset stands alone: no product signup, no API key, no gated content. Prior published work on array coverage (Verlouw 2021 EJHG; Lemieux Perreault 2018 Pharmacogenomics; and others) is cited in the README's *Prior work* section, and **none of the findings are claimed as novel** — the contribution is the machine-readable table, not the science.

**One caveat, stated plainly:** `unknown` is a real value here, not missing work. No consumer vendor publishes a per-chip manifest, so of the 9 consumer products most rows are `unknown` by design rather than guessed. The 5 published arrays are fully resolved.

**Licence:** data and documentation CC BY 4.0; code in `scripts/` MIT. The source manifests are not redistributed — the build script fetches them from the publisher.
