### PR TITLE
Add MideaFind Germany DIY Store Locations dataset

### DIFF
--- a/core/GIS/MideaFind-Germany-DIY-Store-Locations.yml
+++ b/core/GIS/MideaFind-Germany-DIY-Store-Locations.yml
@@ -1,6 +1,6 @@
 ---
 title: MideaFind Germany DIY Store Locations
-homepage: https://mideafind.com/data/stores.de.json
+homepage: https://mideafind.com/marktabdeckung-karte.html#datenqualitaet
 category: GIS
 description: Versioned JSON dataset of 1,314 known DIY-store locations across six retail groups in Germany, derived from an OpenStreetMap Overpass snapshot dated 2 July 2026. Includes retailer, name, address fields, coordinates, OSM source identifiers, attribution, license metadata, and published quality metrics. The dataset describes geographic coverage only and contains no inventory, prices, demand, sales, or retailer-partnership claims.
 version: "2026-07-02"

--- a/core/GIS/MideaFind-Germany-DIY-Store-Locations.yml
+++ b/core/GIS/MideaFind-Germany-DIY-Store-Locations.yml
@@ -1,0 +1,33 @@
+---
+title: MideaFind Germany DIY Store Locations
+homepage: https://mideafind.com/data/stores.de.json
+category: GIS
+description: Versioned JSON dataset of 1,314 known DIY-store locations across six retail groups in Germany, derived from an OpenStreetMap Overpass snapshot dated 2 July 2026. Includes retailer, name, address fields, coordinates, OSM source identifiers, attribution, license metadata, and published quality metrics. The dataset describes geographic coverage only and contains no inventory, prices, demand, sales, or retailer-partnership claims.
+version: "2026-07-02"
+keywords: Germany, DIY stores, retail locations, OpenStreetMap, Overpass, geospatial, point data, STAC
+image:
+temporal: "2026-07-02 snapshot"
+spatial: Germany
+access_level: public
+copyrights: © OpenStreetMap contributors
+accrual_periodicity: irregular
+specification: https://mideafind.com/data/stac/catalog.json
+data_quality: true
+data_dictionary: https://mideafind.com/marktabdeckung-karte.html#datenqualitaet
+language: de, en
+license: Open Data Commons Open Database License 1.0
+publisher:
+  - name: MideaFind
+    web: https://mideafind.com/
+organization:
+  - name:
+    web:
+issued_time: "2026.07"
+sources:
+  - name: OpenStreetMap Overpass API
+    access_url: https://www.openstreetmap.org/
+references:
+  - title: Quality report and methodology
+    reference: https://mideafind.com/data/diy-store-data-quality.json
+  - title: STAC catalog
+    reference: https://mideafind.com/data/stac/catalog.json


### PR DESCRIPTION
## What changed

Adds one GIS metadata entry for a directly downloadable JSON dataset of 1,314 known DIY-store locations across six retail groups in Germany.

## Why it fits

- Public direct download with no login or purchase
- OpenStreetMap/Overpass source with ODbL 1.0 attribution
- Dated 2026-07-02 snapshot with published quality metrics
- STAC 1.1 catalog and explicit scope limits
- Neutral data description: no inventory, prices, demand, sales, or partnership claims

## Validation

- Repository validator passed with Python/PyYAML
- `git diff --check` passed
- Dataset, quality report, landing page, and STAC catalog all returned HTTP 200
- Dataset readback confirmed 1,314 records