### PR TITLE
Add US Visa Bulletin priority-date history + US coin metal-content datasets

### DIFF
--- a/core/Economics/US-Coin-Metal-Content-Melt-Values.yml
+++ b/core/Economics/US-Coin-Metal-Content-Melt-Values.yml
@@ -1,0 +1,38 @@
+---
+title: US Coin Metal Content & Melt Values
+homepage: https://github.com/mixseomin/us-coin-melt-data
+category: Economics
+description: >
+  Fine precious-metal and base-metal content of common US coins (silver and
+  gold in troy ounces, copper and nickel in grams) as JSON and CSV - the stable
+  constants needed to compute coin melt value from live metals spot prices. The
+  canonical junk-silver figures plus copper/nickel circulation coins, sourced
+  from US Mint specifications and the Red Book.
+version: 2026
+keywords: coins, numismatics, silver, gold, melt value, precious metals, junk silver, commodities, United States
+image:
+temporal: 2026
+spatial: United States
+access_level: public
+copyrights: Public fact (US Mint coin specifications)
+accrual_periodicity:
+specification:
+data_quality: true
+data_dictionary: https://github.com/mixseomin/us-coin-melt-data#whats-inside
+language: en
+license: Public domain (coin specifications)
+publisher:
+  - name: mintalmanac.com
+    web: https://mintalmanac.com
+organization:
+  - name: US Mint (source specifications)
+    web: https://www.usmint.gov/learn/coin-and-medal-programs/coin-specifications
+issued_time: 2026
+sources:
+  - name: US Mint coin specifications
+    access_url: https://www.usmint.gov/learn/coin-and-medal-programs/coin-specifications
+references:
+  - title: Coin metal content CSV
+    reference: https://raw.githubusercontent.com/mixseomin/us-coin-melt-data/main/csv/coin-metal-content.csv
+  - title: Compositions JSON
+    reference: https://raw.githubusercontent.com/mixseomin/us-coin-melt-data/main/data/coin-compositions.json

--- a/core/Government/US-Visa-Bulletin-Priority-Dates.yml
+++ b/core/Government/US-Visa-Bulletin-Priority-Dates.yml
@@ -1,0 +1,38 @@
+---
+title: US Visa Bulletin Priority Date History
+homepage: https://github.com/mixseomin/visa-bulletin-history
+category: Government
+description: >
+  The monthly US Department of State Visa Bulletin parsed into structured JSON
+  and CSV. Family-sponsored and employment-based categories, both Final Action
+  Dates and Dates for Filing charts, for all chargeability areas (worldwide,
+  China, India, Mexico, Philippines), as a time series (2,700 rows across 18
+  monthly bulletins, Feb 2025 - Jul 2026). Public-domain US Government data.
+version: 2026
+keywords: immigration, visa bulletin, priority date, green card, USCIS, employment based, family based, United States
+image:
+temporal: 2025-2026
+spatial: United States
+access_level: public
+copyrights: US Government public domain (17 U.S.C. 105)
+accrual_periodicity: monthly
+specification:
+data_quality: true
+data_dictionary: https://github.com/mixseomin/visa-bulletin-history#csv-schema
+language: en
+license: Public Domain (US Government work)
+publisher:
+  - name: visagps.com
+    web: https://visagps.com
+organization:
+  - name: US Department of State (source)
+    web: https://travel.state.gov/content/travel/en/legal/visa-law0/visa-bulletin.html
+issued_time: 2026
+sources:
+  - name: US Department of State Visa Bulletin
+    access_url: https://travel.state.gov/content/travel/en/legal/visa-law0/visa-bulletin.html
+references:
+  - title: Priority dates CSV
+    reference: https://raw.githubusercontent.com/mixseomin/visa-bulletin-history/main/csv/visa-bulletin-priority-dates.csv
+  - title: Full history JSON
+    reference: https://raw.githubusercontent.com/mixseomin/visa-bulletin-history/main/data/history.json


### PR DESCRIPTION
Two US public-domain datasets:

**US Visa Bulletin Priority Date History** (Government) - the State Dept Visa Bulletin parsed to JSON/CSV, family + employment categories, Final Action + Dates for Filing, all chargeability areas, 2,700 rows across 18 monthly bulletins (2025-2026). https://github.com/mixseomin/visa-bulletin-history

**US Coin Metal Content & Melt Values** (Economics) - fine silver/gold/copper/nickel content per US coin type (the constants for computing melt value from live spot), from US Mint specs. https://github.com/mixseomin/us-coin-melt-data