### PR TITLE
Add RestoreRadar U.S. emergency restoration market data (Economics)

### DIFF
--- a/core/Economics/restoreradar-restoration-market-data.yml
+++ b/core/Economics/restoreradar-restoration-market-data.yml
@@ -1,0 +1,58 @@
+---
+title: RestoreRadar U.S. Emergency Restoration Provider Market Data (10-Metro Aggregates)
+homepage: https://restoreradar.com/restoration-market-data/
+category: Economics
+description: >
+  Metro-level aggregate statistics on the public storefront of the U.S. emergency
+  restoration industry (water, fire, mold, storm) across 10 selected metros in
+  Texas, Florida, and Louisiana. Derived from 550 published provider records:
+  provider-stated 24/7 availability and direct insurance billing, Google-rated
+  listing counts and review totals, domain-matched Google Business locations,
+  IICRC Certified Firm registry matches, and official state mold-credential
+  matches. Aggregate-only (10 metro rows), not a provider-level census and not a
+  national sample; methodology and limitations are published alongside the data.
+version: 1.0
+keywords:
+  - restoration industry
+  - water damage restoration
+  - contractor market data
+  - local services
+  - business verification
+  - credential verification
+image:
+temporal: 2026 snapshot (data last modified 2026-07-30; monthly refresh cadence)
+spatial: 10 U.S. metros in Texas, Florida, and Louisiana
+access_level: public
+copyrights: >
+  © 2026 RestoreRadar (ChairFlow Solutions LLC). Aggregates derived from
+  providers' own published websites and official registries; underlying
+  third-party rights are not licensed or waived by RestoreRadar. Reuse terms:
+  https://restoreradar.com/restoration-market-data/#reuse-terms
+accrual_periodicity: monthly
+specification: >
+  CSV/JSON keyed by metro_slug; columns: city, state, listed_providers,
+  provider_stated_24_7, provider_stated_insurance_direct_billing,
+  google_rated_listings, google_review_total,
+  domain_matched_google_business_locations, iicrc_certified_firms,
+  official_state_mold_credentials, date_modified, license_url.
+data_quality: true
+data_dictionary: https://restoreradar.com/restoration-market-data/
+language: en
+license: RestoreRadar custom attribution/reuse terms
+publisher:
+  - name: RestoreRadar
+    web: https://restoreradar.com
+organization:
+  - name: ChairFlow Solutions LLC
+    web: https://restoreradar.com/about/
+issued_time: 2026-08
+sources:
+  - name: RestoreRadar restoration market data (CSV)
+    access_url: https://restoreradar.com/data/restoration-market-data.csv
+  - name: RestoreRadar restoration market data (JSON)
+    access_url: https://restoreradar.com/data/restoration-market-data.json
+references:
+  - title: Methodology, limitations, and reuse terms
+    reference: https://restoreradar.com/restoration-market-data/
+  - title: Reuse terms (mirror)
+    reference: https://raw.githubusercontent.com/chrishowardtx/restoreradar-market-data/main/REUSE_TERMS.md

--- a/core/Economics/restoreradar-restoration-market-data.yml
+++ b/core/Economics/restoreradar-restoration-market-data.yml
@@ -6,7 +6,7 @@ description: >
   Metro-level aggregate statistics on the public storefront of the U.S. emergency
   restoration industry (water, fire, mold, storm) across 10 selected metros in
   Texas, Florida, and Louisiana. Derived from 550 published provider records:
-  provider-stated 24/7 availability and direct insurance billing, Google-rated
+  provider-stated 24/7 response and direct insurance billing, Google-rated
   listing counts and review totals, domain-matched Google Business locations,
   IICRC Certified Firm registry matches, and official state mold-credential
   matches. Aggregate-only (10 metro rows), not a provider-level census and not a
@@ -20,7 +20,7 @@ keywords:
   - business verification
   - credential verification
 image:
-temporal: 2026 snapshot (data last modified 2026-07-30; monthly refresh cadence)
+temporal: 2026 snapshot (data last modified 2026-07-30; no fixed calendar schedule)
 spatial: 10 U.S. metros in Texas, Florida, and Louisiana
 access_level: public
 copyrights: >
@@ -28,7 +28,7 @@ copyrights: >
   providers' own published websites and official registries; underlying
   third-party rights are not licensed or waived by RestoreRadar. Reuse terms:
   https://restoreradar.com/restoration-market-data/#reuse-terms
-accrual_periodicity: monthly
+accrual_periodicity: irregular; recomputed with each published RestoreRadar data refresh; no fixed calendar schedule
 specification: >
   CSV/JSON keyed by metro_slug; columns: city, state, listed_providers,
   provider_stated_24_7, provider_stated_insurance_direct_billing,


### PR DESCRIPTION
One new entry: `core/Economics/restoreradar-restoration-market-data.yml`.

**What the dataset is:** metro-level aggregate statistics on the public storefront of the U.S. emergency restoration industry (water/fire/mold/storm) across 10 selected metros in Texas, Florida, and Louisiana. The downloadable CSV/JSON contains 10 aggregate metro rows derived from 550 published provider records: provider-stated 24/7 and direct-insurance-billing counts, Google-rated listing counts and review totals, domain-matched Google Business locations, IICRC Certified Firm registry matches, and official state mold-credential matches. It is aggregate-only — not a provider-level census and not a national sample. Methodology and limitations are published alongside the data.

**Direct downloads:**
- CSV: https://restoreradar.com/data/restoration-market-data.csv
- JSON: https://restoreradar.com/data/restoration-market-data.json
- Methodology/data dictionary: https://restoreradar.com/restoration-market-data/

**License:** custom attribution/reuse terms (linked in the entry), with an explicit third-party-rights carveout — deliberately **not** labeled CC or open-source.

**Disclosure:** the dataset is published by RestoreRadar (ChairFlow Solutions LLC), a commercial free-to-use restoration directory; I'm submitting as its operator. The entry follows the Economics precedent of commercial-origin datasets (e.g. prop-metrics) and is written neutrally per the contribution policy.

`tests/validate.py` passes locally (exit 0) including the new entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)