### PR TITLE
Add NutrientsDB Nutrition Database under Healthcare

### DIFF
--- a/core/Healthcare/NutrientsDB-Nutrition-Database.yml
+++ b/core/Healthcare/NutrientsDB-Nutrition-Database.yml
@@ -15,8 +15,12 @@ organization:
   - name: NutrientsDB
     web: https://www.nutrientsdb.com/
 sources:
+  - name: NutrientsDB JSON sample on GitHub
+    access_url: https://raw.githubusercontent.com/colinearstudio/nutrientsdb-sample/main/sample.json
   - name: NutrientsDB JSON sample on Hugging Face
     access_url: https://huggingface.co/datasets/colinearstudio/nutrientsdb/resolve/main/sample.json?download=true
 references:
-  - title: NutrientsDB sample dataset page
+  - title: NutrientsDB sample repository on GitHub
+    reference: https://github.com/colinearstudio/nutrientsdb-sample
+  - title: NutrientsDB sample dataset on Hugging Face
     reference: https://huggingface.co/datasets/colinearstudio/nutrientsdb

--- a/core/Healthcare/NutrientsDB-Nutrition-Database.yml
+++ b/core/Healthcare/NutrientsDB-Nutrition-Database.yml
@@ -2,9 +2,11 @@
 title: NutrientsDB Nutrition Database
 homepage: https://www.nutrientsdb.com/
 category: Healthcare
-description: Nutrition database containing 2.9M+ food records with global coverage, normalized to a common schema of 86 nutrient fields and standard units. A public 1,000-record JSON sample uses the same schema.
+description: Nutrition database containing 2.9M+ food records with global coverage, normalized to a common schema of 86 nutrient fields and standard units. A free public 1,000-record JSON sample uses the same schema.
 keywords: nutrition,food composition,nutrients,standardized units,JSON
-access_level: Public sample; full dataset requires purchase
+access_level: Free public 1,000-record sample; full dataset requires purchase
+specification: JSON; the public sample uses the same 86-field schema as the full dataset
+data_dictionary: https://www.nutrientsdb.com/docs
 language: en
 publisher:
   - name: NutrientsDB
@@ -13,5 +15,8 @@ organization:
   - name: NutrientsDB
     web: https://www.nutrientsdb.com/
 sources:
-  - name: NutrientsDB JSON sample
-    access_url: https://huggingface.co/datasets/colinearstudio/nutrientsdb
+  - name: NutrientsDB JSON sample on Hugging Face
+    access_url: https://huggingface.co/datasets/colinearstudio/nutrientsdb/resolve/main/sample.json?download=true
+references:
+  - title: NutrientsDB sample dataset page
+    reference: https://huggingface.co/datasets/colinearstudio/nutrientsdb

--- a/core/Healthcare/NutrientsDB-Nutrition-Database.yml
+++ b/core/Healthcare/NutrientsDB-Nutrition-Database.yml
@@ -1,0 +1,17 @@
+---
+title: NutrientsDB Nutrition Database
+homepage: https://www.nutrientsdb.com/
+category: Healthcare
+description: Nutrition database containing 2.9M+ food records with global coverage, normalized to a common schema of 86 nutrient fields and standard units. A public 1,000-record JSON sample uses the same schema.
+keywords: nutrition,food composition,nutrients,standardized units,JSON
+access_level: Public sample; full dataset requires purchase
+language: en
+publisher:
+  - name: NutrientsDB
+    web: https://www.nutrientsdb.com/
+organization:
+  - name: NutrientsDB
+    web: https://www.nutrientsdb.com/
+sources:
+  - name: NutrientsDB JSON sample
+    access_url: https://huggingface.co/datasets/colinearstudio/nutrientsdb


### PR DESCRIPTION
Adds the NutrientsDB Nutrition Database: 2.9M+ food records with global coverage and 86 nutrient fields normalized to standard units.

- Free public JSON sample, no login: https://raw.githubusercontent.com/colinearstudio/nutrientsdb-sample/main/sample.json (1,000 records)
- Hugging Face mirror: https://huggingface.co/datasets/colinearstudio/nutrientsdb
- Schema and data dictionary: https://www.nutrientsdb.com/docs

The repository validator passes locally with the new entry.