### PR TITLE
Add Donald Trump Truth Social Posts Archive

### DIFF
--- a/core/SocialNetworks/Donald-Trump-Truth-Social-Posts-Archive.yml
+++ b/core/SocialNetworks/Donald-Trump-Truth-Social-Posts-Archive.yml
@@ -3,16 +3,16 @@ title: Donald Trump Truth Social Posts Archive
 homepage: https://huggingface.co/datasets/Cameronk199/donald-trump-truth-social-posts
 category: SocialNetworks
 description: >
-  A source-linked archive of 35,891 public Truth Social posts associated with
+  A source-linked archive of 35,882 public Truth Social posts associated with
   Donald J. Trump's @realDonaldTrump account, covering February 2022 through
   August 2026. The release includes timestamps, post types, original HTML,
   extracted text, source URLs, analysis-ready Parquet and JSONL tables, 8,004
   verified image derivatives with provenance indexes, and metadata or
-  transcripts for 5,757 video attachments.
-version: 2026.08.03
+  transcripts for 5,756 video attachments.
+version: 2026.08.02
 keywords: truth social, donald trump, social media, politics, nlp, text analysis, images, parquet, time series
 image: https://huggingface.co/spaces/Cameronk199/truth-social-timeline-explorer/resolve/main/assets/truth-social-posting-volume.png
-temporal: 2022-02-14 to 2026-08-03
+temporal: 2022-02-14 to 2026-08-02
 spatial:
 access_level: public
 copyrights: Underlying post and media rights may belong to authors, uploaders, or third parties.

--- a/core/SocialNetworks/Donald-Trump-Truth-Social-Posts-Archive.yml
+++ b/core/SocialNetworks/Donald-Trump-Truth-Social-Posts-Archive.yml
@@ -1,0 +1,37 @@
+---
+title: Donald Trump Truth Social Posts Archive
+homepage: https://huggingface.co/datasets/Cameronk199/donald-trump-truth-social-posts
+category: SocialNetworks
+description: >
+  A source-linked archive of 35,891 public Truth Social posts associated with
+  Donald J. Trump's @realDonaldTrump account, covering February 2022 through
+  August 2026. The release includes timestamps, post types, original HTML,
+  extracted text, source URLs, analysis-ready Parquet and JSONL tables, 8,004
+  verified image derivatives with provenance indexes, and metadata or
+  transcripts for 5,757 video attachments.
+version: 2026.08.03
+keywords: truth social, donald trump, social media, politics, nlp, text analysis, images, parquet, time series
+image: https://huggingface.co/spaces/Cameronk199/truth-social-timeline-explorer/resolve/main/assets/truth-social-posting-volume.png
+temporal: 2022-02-14 to 2026-08-03
+spatial:
+access_level: public
+copyrights: Underlying post and media rights may belong to authors, uploaders, or third parties.
+accrual_periodicity: weekly
+specification: https://huggingface.co/datasets/Cameronk199/donald-trump-truth-social-posts#fields
+data_quality: true
+data_dictionary: https://huggingface.co/datasets/Cameronk199/donald-trump-truth-social-posts#fields
+language: en
+license: Other; see the dataset rights and attribution notice
+publisher:
+  - name: Cameron Keplinger
+    web: https://huggingface.co/Cameronk199
+organization: []
+issued_time: 2026.06
+sources:
+  - name: Trumpstruth public status-detail archive
+    access_url: https://trumpstruth.org/
+references:
+  - title: Interactive timeline and search explorer
+    reference: https://huggingface.co/spaces/Cameronk199/truth-social-timeline-explorer
+  - title: Kaggle mirror
+    reference: https://www.kaggle.com/datasets/cameronkeplinger/donald-trump-truth-social-posts


### PR DESCRIPTION
## What this adds

Adds the Donald Trump Truth Social Posts Archive to the `SocialNetworks` category.

The public, source-linked release contains 35,882 posts from February 2022 through August 2026 in Parquet and JSONL formats. It also includes provenance-preserving indexes for 8,004 verified image derivatives and 5,756 video attachment records.

## Quality and access

- Direct public download without login
- Source URLs retained for every post
- Reconciled unique IDs with zero duplicate post IDs in the current release
- Data dictionary, limitations, rights notice, and reproducible checksums included
- Updated weekly

## Validation

Ran `tests/validate.py` successfully against the full `apd-core` catalog.
