### PR TITLE
Add Crawlora Jobs, US Housing Markets, X Users, and GitHub Users datasets

### DIFF
--- a/core/Economics/Jobs-Dataset-Hiring-Intelligence.yml
+++ b/core/Economics/Jobs-Dataset-Hiring-Intelligence.yml
@@ -1,0 +1,33 @@
+---
+title: 'Jobs Dataset: 69,826 company career boards, 1.93M live postings'
+homepage: https://crawlora.net/datasets/jobs
+category: Economics
+description: A normalized hiring-market index built from 69,826 discovered company career-site boards across 16 applicant-tracking-system providers (Greenhouse, Lever, Ashby, Workday, SmartRecruiters, Workable, Recruitee, Rippling, Personio, Teamtailor, Oracle, UKG, iCIMS, Eightfold, Gem, Pinpoint), plus 5 single-company big-tech careers platforms (Amazon, Apple, Google, Meta, Tesla) — 1,934,195 live public job postings in total, normalized into one cross-provider JSON shape with company, department, location, employment type, remote flag, and compensation where disclosed. Public postings only, no login required.
+version: 1.0.0
+keywords: jobs dataset, hiring data, ats job postings, labor market data, company career pages, greenhouse workday lever, remote jobs data, compensation data
+image:
+temporal: 2026
+spatial: Worldwide
+access_level: public
+copyrights:
+accrual_periodicity: continuous
+specification:
+data_quality: true
+data_dictionary: https://crawlora.net/datasets/jobs
+language: en
+license: CC BY 4.0
+publisher:
+- name: Crawlora
+  web: https://crawlora.net
+organization:
+- name: Crawlora
+  web: https://crawlora.net
+issued_time: 2026
+sources:
+- name: Interactive dataset page and live query API
+  access_url: https://crawlora.net/datasets/jobs
+- name: API documentation
+  access_url: https://crawlora.net/docs/datasets/datasets-jobs-search
+references:
+- title: The Job Market Runs on Workday (Crawlora blog)
+  reference: https://crawlora.net/blog/job-market-runs-on-workday-2026

--- a/core/Economics/US-Housing-Markets-Dataset.yml
+++ b/core/Economics/US-Housing-Markets-Dataset.yml
@@ -1,0 +1,33 @@
+---
+title: 'US Housing Markets Dataset: 52,051 regions, monthly since 2012'
+homepage: https://crawlora.net/datasets/housing
+category: Economics
+description: Redfin market statistics for 52,051 US regions (metro, county, city, and ZIP level), tracked monthly since 2012 and joined to Census income data to derive price-to-income ratios and the salary needed to buy the median home in each region. Aggregate market data only, queryable over one REST API.
+version: 1.0.0
+keywords: housing market dataset, home price to income, housing affordability data, redfin data, us home prices by zip, real estate market data, salary to buy a house
+image:
+temporal: 2012-2026
+spatial: United States
+access_level: public
+copyrights:
+accrual_periodicity: monthly
+specification:
+data_quality: true
+data_dictionary: https://crawlora.net/datasets/housing
+language: en
+license: CC BY 4.0
+publisher:
+- name: Crawlora
+  web: https://crawlora.net
+organization:
+- name: Crawlora
+  web: https://crawlora.net
+issued_time: 2026
+sources:
+- name: Interactive dataset page and live query API
+  access_url: https://crawlora.net/datasets/housing
+- name: API documentation
+  access_url: https://crawlora.net/docs/datasets/datasets-housing-markets-search
+references:
+- title: Housing Is Unaffordable in America (Crawlora blog)
+  reference: https://crawlora.net/blog/housing-unaffordable-america-2026

--- a/core/SocialNetworks/X-Twitter-Users-Dataset.yml
+++ b/core/SocialNetworks/X-Twitter-Users-Dataset.yml
@@ -1,0 +1,33 @@
+---
+title: 'X (Twitter) Users Dataset: 796,611 public profiles'
+homepage: https://crawlora.net/datasets/x-users
+category: SocialNetworks
+description: A seeded index of 796,611 public X (Twitter) profiles, sourced from independent public lists (Wikidata entities, public GitHub developers, startup founders, journalists) and kept updated against live profiles — followers, bio, external link, blue-check status, and account age, queryable over one REST API. Public profile fields only; no login required and not a random sample of X.
+version: 1.0.0
+keywords: x users dataset, twitter users dataset, x profile data, twitter follower dataset, social profile intelligence, twitter account age, blue check dataset
+image:
+temporal: 2026
+spatial: Worldwide
+access_level: public
+copyrights:
+accrual_periodicity: continuous
+specification:
+data_quality: true
+data_dictionary: https://crawlora.net/datasets/x-users
+language: en
+license: CC BY 4.0
+publisher:
+- name: Crawlora
+  web: https://crawlora.net
+organization:
+- name: Crawlora
+  web: https://crawlora.net
+issued_time: 2026
+sources:
+- name: Interactive dataset page and live query API
+  access_url: https://crawlora.net/datasets/x-users
+- name: API documentation
+  access_url: https://crawlora.net/docs/datasets/datasets-x-users-search
+references:
+- title: What X Bios Reveal About Who's Building AI (Crawlora blog)
+  reference: https://crawlora.net/blog/x-bios-mention-ai-labs-2026

--- a/core/Software/GitHub-Users-Dataset.yml
+++ b/core/Software/GitHub-Users-Dataset.yml
@@ -1,0 +1,33 @@
+---
+title: 'GitHub Users Dataset: 982,618 enriched developer profiles'
+homepage: https://crawlora.net/datasets/github-users
+category: Software
+description: 982,618 enriched public GitHub developer profiles — followers, company, stated interests, activity signals, and clean resolved geo on 97.1% of located accounts — queryable over one REST API. Public profile fields only.
+version: 1.0.0
+keywords: github users dataset, github developer data, developer profiles, github followers dataset, developer intelligence, developer geo dataset, open source contributor data
+image:
+temporal: 2026
+spatial: Worldwide
+access_level: public
+copyrights:
+accrual_periodicity: continuous
+specification:
+data_quality: true
+data_dictionary: https://crawlora.net/datasets/github-users
+language: en
+license: CC BY 4.0
+publisher:
+- name: Crawlora
+  web: https://crawlora.net
+organization:
+- name: Crawlora
+  web: https://crawlora.net
+issued_time: 2026
+sources:
+- name: Interactive dataset page and live query API
+  access_url: https://crawlora.net/datasets/github-users
+- name: API documentation
+  access_url: https://crawlora.net/docs/datasets/datasets-github-users-search
+references:
+- title: Where Developers Live, By GitHub Followers (Crawlora blog)
+  reference: https://crawlora.net/blog/where-developers-live-github-2026


### PR DESCRIPTION
Adds 4 new dataset entries, following the same format as #480/#523:

- **core/Economics/Jobs-Dataset-Hiring-Intelligence.yml** — 69,826 discovered company career-site boards across 16 ATS providers, 1,934,195 live job postings, normalized cross-provider JSON.
- **core/Economics/US-Housing-Markets-Dataset.yml** — Redfin market stats for 52,051 US regions, monthly since 2012, joined to Census income data.
- **core/SocialNetworks/X-Twitter-Users-Dataset.yml** — 796,611 public X (Twitter) profiles with followers, bio, blue-check status, and account age.
- **core/Software/GitHub-Users-Dataset.yml** — 982,618 enriched public GitHub developer profiles with resolved geo, company, and activity signals.

All four are live, queryable via a free-tier REST API, CC BY 4.0 licensed, and validated locally against `tests/validate.py` (full-repo run passes, exit 0).