### PR TITLE
Name Kültür Envanteri and its CC BY requirement in the Kahve Tabela entry

### DIFF
--- a/core/Museums/Turkiye-Cultural-Heritage-Atlas-Kahve-Tabela.yml
+++ b/core/Museums/Turkiye-Cultural-Heritage-Atlas-Kahve-Tabela.yml
@@ -2,7 +2,7 @@
 title: Türkiye Cultural Heritage Atlas (Kahve Tabela) Open Data
 homepage: https://kahvetabela.com/tr/acik-veri
 category: Museums
-description: 32,483 registered cultural-heritage places in Türkiye (name, category, province, district, WGS84 coordinates, audited Wikidata IDs) plus 1,679 geographical-indication registered regional foods from the public TürkPatent registry. Direct-download versioned CSV/JSON dumps with a sha256 integrity manifest, and a free JSON API with an OpenAPI spec. Compiled from public sources including Wikidata, OpenStreetMap and TürkPatent.
+description: 32,483 registered cultural-heritage places in Türkiye (name, category, province, district, WGS84 coordinates, audited Wikidata IDs) plus 1,679 geographical-indication registered regional foods from the public TürkPatent registry. Direct-download versioned CSV/JSON dumps with a sha256 integrity manifest, and a free JSON API with an OpenAPI spec. Compiled from public sources. Roughly half the heritage records come from Kültür Envanteri (CC BY, attribution required), the rest from Wikidata, OpenStreetMap and the public TürkPatent registry.
 version: 2026-07
 keywords: Turkey, cultural heritage, archaeology, museums, geographical indication, geospatial
 image:
@@ -15,7 +15,7 @@ specification: https://kahvetabela.com/openapi.json
 data_quality: true
 data_dictionary: https://kahvetabela.com/tr/acik-veri
 language: tr, en
-license: ODbL (location database), CC0 (Wikidata-derived fields); attribute the compilation to Kahve Tabela
+license: CC BY (Kültür Envanteri-derived records, attribution required), ODbL (location database via OpenStreetMap), CC0 (Wikidata-derived fields), public registry (TürkPatent); attribute the compilation to Kahve Tabela
 publisher:
   - name: Kahve Tabela
     web: https://kahvetabela.com
@@ -26,6 +26,10 @@ issued_time: 2026.07
 sources:
   - name: Data dumps index (sha256 manifest)
     access_url: https://kahvetabela.com/dumps/index.json
+  - name: Kültür Envanteri (CC BY), largest single source
+    access_url: https://kulturenvanteri.com
+  - name: Full source and licence table
+    access_url: https://kahvetabela.com/tr/acik-veri
 references:
   - title:
     reference:


### PR DESCRIPTION
Thanks for merging #511 earlier today. Following up on it with a correction to my own entry.

It listed Wikidata, OpenStreetMap and TürkPatent as the sources and left out the largest one: roughly **half the heritage records (16,410 of 32,341) come from [Kültür Envanteri](https://kulturenvanteri.com), which is shared under CC BY** and therefore requires attribution. Someone reusing the dumps from this entry alone would not have known that, which is my mistake to fix rather than theirs to discover.

Three fields change:

- **`description`** now says where the records come from, naming Kültür Envanteri and its CC BY condition alongside the other sources.
- **`license`** leads with the CC BY obligation instead of listing only ODbL and CC0.
- **`sources`** gains `kulturenvanteri.com` and the full source-and-licence table at `/tr/acik-veri`.

Nothing else is touched. The YAML was validated, along with the other eight entries in `core/Museums/`, to be sure the edit did not break parsing.
