### PR TITLE
Evidaxis Momentum Snapshots: mark the series as ongoing

### DIFF
--- a/core/MachineLearning/Evidaxis-Momentum-Snapshots.yml
+++ b/core/MachineLearning/Evidaxis-Momentum-Snapshots.yml
@@ -11,7 +11,7 @@ description: Weekly, hash-pinned point-in-time measurements of rising open-sourc
 version: 1.0
 keywords: open-source AI, momentum, longitudinal, time series, scientometrics
 image:
-temporal: 2026-06-27/2026-07-11
+temporal: 2026-06-27/..
 spatial:
 access_level: public
 copyrights:


### PR DESCRIPTION
The dataset is updated weekly, but `temporal` pinned an end date, so the card reads as a series that stopped on 2026-07-11. Replaced with the open-ended interval notation used by schema.org `temporalCoverage` (`2026-06-27/..`), which keeps the metadata true without periodic edits.