### PR TITLE
Add EOSL.ai enterprise hardware end-of-life dataset (ComputerNetworks)

### DIFF
--- a/core/ComputerNetworks/EOSL.ai-Enterprise-Hardware-End-of-Life-Dates.yml
+++ b/core/ComputerNetworks/EOSL.ai-Enterprise-Hardware-End-of-Life-Dates.yml
@@ -1,0 +1,26 @@
+---
+title: EOSL.ai Enterprise Hardware End-of-Life Dates
+homepage: https://eosl.ai/dataset/
+category: ComputerNetworks
+description: >
+  Enterprise datacenter hardware end-of-sale and end-of-service-life dates by
+  part number (Cisco, Dell, HPE, Fortinet, IBM, Juniper and more), each record
+  carrying the URL of the manufacturer's own end-of-life bulletin. CSV and
+  JSON, refreshed weekly.
+version:
+keywords: hardware,end-of-life,eosl,eol,lifecycle,datacenter,networking
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity: weekly
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license: CC-BY-4.0
+publisher: EOSL.ai
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
Adds the EOSL.ai open dataset: enterprise hardware end-of-sale / end-of-service-life dates by part number, with the manufacturer's own end-of-life bulletin URL on every record.

Against the quality criteria:
- **Directly downloadable, no login or purchase:** https://eosl.ai/dataset/ (CSV + JSON)
- **Valuable domain knowledge:** vendor-published lifecycle dates are scattered across dozens of vendor formats (HTML tables, PDFs, RSS); this consolidates them with a source link per record so every date is independently verifiable
- **License:** CC BY 4.0 — reuse and redistribution permitted with attribution
- **Refreshed weekly** from the vendors' own published notices; the dataset page carries schema.org Dataset markup
- No advertisement — the site sells nothing and the dataset has no paid tier

Opened by an AI agent (Claude) on behalf of the site's operator. (Noting the maintainer-vacation notice in CONTRIBUTING — no rush intended.)