### PR TITLE
Add BaZi Nayin: Chinese-English terminology mapping (NaturalLanguage)

### DIFF
--- a/core/NaturalLanguage/bazi-nayin.yml
+++ b/core/NaturalLanguage/bazi-nayin.yml
@@ -1,0 +1,32 @@
+---
+title: BaZi Nayin - Chinese-English terminology mapping
+homepage: https://github.com/Shann5/bazi-nayin
+category: NaturalLanguage
+description: The thirty nayin (纳音) of the Chinese sexagenary calendar with English translations, as JSON and CSV. Each of the 30 entries gives the Chinese term, tone-marked pinyin, an English rendering, the Five-Element class, and the two stem-branch (ganzhi) pairs it covers, so all 60 calendar pairs are keyed. English sources render these terms inconsistently - the same term appears three or four different ways across sources, which makes them impossible to join across datasets - so this set fixes one rendering and documents the principles behind it.
+version: 1.0
+keywords: chinese, chinese-english, bilingual, terminology, glossary, translation, sexagenary cycle, nayin
+temporal:
+spatial:
+access_level: public
+copyrights: Auspice Oracle
+accrual_periodicity:
+specification: https://github.com/Shann5/bazi-nayin#the-table
+data_quality: false
+data_dictionary: https://github.com/Shann5/bazi-nayin#data
+language: en, zh
+license: CC-BY-4.0
+publisher:
+  - name: Auspice Oracle
+    web: https://auspiceoracle.com
+organization:
+  - name: Auspice Oracle
+    web: https://auspiceoracle.com
+issued_time: 2026.08
+sources:
+  - name: nayin.json
+    access_url: https://raw.githubusercontent.com/Shann5/bazi-nayin/main/data/nayin.json
+  - name: nayin.csv
+    access_url: https://raw.githubusercontent.com/Shann5/bazi-nayin/main/data/nayin.csv
+references:
+  - title: The 30 Nayin, explained
+    reference: https://auspiceoracle.com/en/content/nayin


### PR DESCRIPTION
Adds `core/NaturalLanguage/bazi-nayin.yml`.

**What it is.** A 30-row bilingual terminology mapping: the *nayin* (纳音) terms of the Chinese sexagenary calendar, each with tone-marked pinyin, an English rendering, a category label, and the two stem-branch pairs it covers — so all 60 calendar pairs are keyed. JSON and CSV, no login, no API key.

**Why it belongs in NaturalLanguage.** It is a terminology resource rather than a corpus. English sources render these terms three or four different ways, so they cannot be joined across datasets; this fixes one rendering and documents the principles behind each choice, which makes the choices arguable rather than arbitrary. Nearest neighbours already in this category are the other lexical/terminology entries (Etymology Atlas, World Languages, WordNet).

**Checks**
- [x] `python tests/validate.py` passes (exit 0, file picked up)
- [x] Direct download, no authentication: [nayin.json](https://raw.githubusercontent.com/Shann5/bazi-nayin/main/data/nayin.json) · [nayin.csv](https://raw.githubusercontent.com/Shann5/bazi-nayin/main/data/nayin.csv)
- [x] License is explicit and machine-readable: CC BY 4.0 (GitHub reports SPDX `CC-BY-4.0`)
- [x] Category matches the folder name

I maintain the dataset, so flagging that plainly. It is CC BY 4.0 open data with no signup and nothing to sell; if you would rather this category stayed corpus-only, say so and I will close it.