### PR TITLE
Add US Wage Atlas (pay-band width and price-adjusted pay) under Economics

### DIFF
--- a/core/Economics/US-Wage-Atlas.yml
+++ b/core/Economics/US-Wage-Atlas.yml
@@ -3,7 +3,7 @@ title: US Wage Atlas - Pay Band Width and Price-Adjusted Pay by Occupation and M
 homepage: https://voicedapp.co/datasets
 category: Economics
 description: Two derived CSV datasets covering every occupation published in every US metro area. The first gives the p25-p75 pay band inside a single occupation in a single place, as a ratio, in dollars and as a share of the median (65,448 rows). The second divides the same wages by the BEA Regional Price Parity for that metro to express pay in national-average dollars, keeping the housing parity as its own column rather than averaging it into a single cost-of-living score (47,380 rows). Artefact rows where adjacent published percentiles collapse onto one value are flagged and excluded from analysis rather than silently dropped.
-version: 1.0
+version: v2025.1
 keywords: wages, salaries, labor market, occupations, metro areas, cost of living, purchasing power, price parities, BLS, BEA, CSV
 image:
 temporal: May 2025 wages, 2024 price parities
@@ -29,3 +29,5 @@ sources:
 references:
   - title: Build scripts and source files
     reference: https://github.com/AndreySoloviev/us-wage-atlas
+  - title: Archived release with permanent DOI
+    reference: https://doi.org/10.5281/zenodo.21827449

--- a/core/Economics/US-Wage-Atlas.yml
+++ b/core/Economics/US-Wage-Atlas.yml
@@ -1,0 +1,31 @@
+---
+title: US Wage Atlas - Pay Band Width and Price-Adjusted Pay by Occupation and Metro Area
+homepage: https://voicedapp.co/datasets
+category: Economics
+description: Two derived CSV datasets covering every occupation published in every US metro area. The first gives the p25-p75 pay band inside a single occupation in a single place, as a ratio, in dollars and as a share of the median (65,448 rows). The second divides the same wages by the BEA Regional Price Parity for that metro to express pay in national-average dollars, keeping the housing parity as its own column rather than averaging it into a single cost-of-living score (47,380 rows). Artefact rows where adjacent published percentiles collapse onto one value are flagged and excluded from analysis rather than silently dropped.
+version: 1.0
+keywords: wages, salaries, labor market, occupations, metro areas, cost of living, purchasing power, price parities, BLS, BEA, CSV
+image:
+temporal: May 2025 wages, 2024 price parities
+spatial: United States, 528 OEWS areas and 387 BEA metro areas
+access_level: public
+copyrights:
+accrual_periodicity: annual
+specification:
+data_quality: false
+data_dictionary: https://voicedapp.co/datasets
+language: en
+license: CC-BY-4.0
+publisher:
+  name: Voiced
+  web: https://voicedapp.co
+organization:
+issued_time: 2026.08
+sources:
+  - name: BLS Occupational Employment and Wage Statistics, May 2025
+    access_url: https://www.bls.gov/oes/tables.htm
+  - name: BEA Regional Price Parities by MSA, 2024
+    access_url: https://www.bea.gov/data/prices-inflation/regional-price-parities-state-and-metro-area
+references:
+  - title: Build scripts and source files
+    reference: https://github.com/AndreySoloviev/us-wage-atlas


### PR DESCRIPTION
Adds one entry under `Economics`: two derived CSV datasets built from BLS OEWS and BEA Regional Price Parities.

**What it adds that the source tables do not have**

- **Pay-band width** (65,448 rows): the p25–p75 gap inside a single occupation in a single metro area, expressed as a ratio, in dollars and as a share of the median. BLS publishes the percentiles; the gap between them and its behaviour across places is not published.
- **Price-adjusted pay** (47,380 rows): the same wages divided by that metro's Regional Price Parity, so pay is expressed in national-average dollars. The housing parity ships as its own column instead of being averaged into one cost-of-living figure, because housing varies about five times as much across metros as the all-items level does.

**Quality notes**

OEWS collects wages in fixed intervals, and when enough of an occupation lands in one interval, adjacent published percentiles collapse onto the same value and any derived ratio becomes meaningless (firefighters in Bakersfield-Delano report p75 = p90 = $470,940 against a median of $72,410). Those rows carry `interval_collapse_flag` and are excluded from analysis rather than silently dropped. `All Other` residual SOC buckets are flagged separately. Both source reference periods ship as columns because they differ by one year (May 2025 wages, 2024 price parities).

**Access**: direct CSV download, no login, no registration. CC BY 4.0; the underlying federal data is public domain.

**Reproducibility**: build scripts and source files are at https://github.com/AndreySoloviev/us-wage-atlas. The builds are deterministic, the OEWS × BEA join is verified metro name by metro name and fails rather than proceeding if the delineation vintages disagree.

Column reference and downloads: https://voicedapp.co/datasets