### PR TITLE
Add Visa Requirements Dataset (Transportation)

### DIFF
--- a/core/Transportation/Visa-Requirements-Dataset.yml
+++ b/core/Transportation/Visa-Requirements-Dataset.yml
@@ -1,0 +1,22 @@
+---
+title: Visa Requirements Dataset
+homepage: https://github.com/maxix7/visa-requirements-dataset
+category: Transportation
+description: Short-stay tourist entry requirements for all 38,612 passport-destination pairs (197 passports, 197 destinations), normalised into six values - visa free, visa on arrival, electronic travel authorisation, e-visa, visa required, no admission - with the permitted stay in days where the destination publishes one. Corrections carry a primary government source and the date a human last re-read it.
+version: 2026-08-06.1
+keywords: visa, passport, immigration, travel, border, entry requirements
+image:
+temporal: 2026-02-17/2026-08-03
+spatial: World
+access_level: public
+copyrights: CC BY 4.0
+accrual_periodicity: irregular
+specification: https://github.com/maxix7/visa-requirements-dataset/blob/main/data/datapackage.json
+data_quality: false
+data_dictionary: https://github.com/maxix7/visa-requirements-dataset/blob/main/data/datapackage.json
+language: en
+license: CC-BY-4.0
+publisher: VisaChecker
+organization: VisaChecker
+issued_time: 2026-08-06
+sources: []


### PR DESCRIPTION
Adds `core/Transportation/Visa-Requirements-Dataset.yml`.

**What it is.** Short-stay tourist entry requirements for all 38,612 passport-destination pairs (197 passports, 197 destinations), normalised into six values: visa free, visa on arrival, electronic travel authorisation, e-visa, visa required, no admission — with the permitted stay in days where the destination publishes one.

- Repository: https://github.com/maxix7/visa-requirements-dataset
- Archived with a DOI: https://doi.org/10.5281/zenodo.21828100
- Licence: CC BY 4.0
- Formats: CSV, JSON, and a Frictionless `datapackage.json`

**Why it might be worth listing.** Visa tables on the web are mostly copies of copies — a Wikipedia article scraped into a repository, that repository scraped into an API, and nobody in the chain holding a link back to a government page. This one records, for every value that departs from the base snapshot, the government page it was read from and the date a human last read it, and corrections are logged in `data/changes.csv` rather than silently edited.

176 of the 38,612 rows carry a primary source today. That number is deliberately not inflated — it is the number that can be defended, and it is stated plainly in the README.

Happy to move it to `Government` instead if that fits the taxonomy better.