### PR TITLE
Add dataset: Most Expensive Watches Auction Records (Economics)

### DIFF
--- a/core/Economics/Most-Expensive-Watches-Auction-Records.yml
+++ b/core/Economics/Most-Expensive-Watches-Auction-Records.yml
@@ -1,0 +1,20 @@
+title: Most Expensive Watches Auction Records
+homepage: https://mostexpensivewatches.net/api
+category: Economics
+description: Documented luxury-watch auction results — 1,156 verified hammer prices from 1996 to 2026, up to $31M (Patek Philippe Grandmaster Chime, Only Watch 2019), across Patek Philippe, Rolex, F.P. Journe and 20+ other makers. Each lot carries reference, case material, venue, sale year and a primary-source link. Includes per-brand all-time records, a $1M+ market index and a matched-lot price index, updated daily. Delivered as JSON datasets and a free no-auth REST API (OpenAPI 3.1), plus an MCP server and Python CLI.
+version: 1.0
+keywords: watches, luxury goods, auctions, hammer prices, collectibles, alternative assets, price index, time series
+image:
+temporal: 1996-2026
+spatial: worldwide
+access_level: public
+copyrights: CC-BY-4.0
+accrual_periodicity: daily
+specification: https://mostexpensivewatches.net/openapi.json
+data_quality: true
+data_dictionary: https://mostexpensivewatches.net/api
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: MostExpensiveWatches.net
+    web: https://mostexpensivewatches.net/


### PR DESCRIPTION
Adds **Most Expensive Watches Auction Records** to `core/Economics/`.

- 1,156 documented luxury-watch auction results (1996–2026), hammer prices up to $31M, each lot with reference, venue, sale year and primary-source link
- Free, no-auth JSON API + bulk dataset, OpenAPI 3.1 spec, CC-BY 4.0
- Updated daily; also exposed as an MCP server and a Python CLI
- Homepage/docs: https://mostexpensivewatches.net/api — bulk: https://mostexpensivewatches.net/api/auctions-dataset.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)