### PR TITLE
Add ByKaranteli crypto derivatives datasets under Finance

### DIFF
--- a/core/Finance/ByKaranteli-Crypto-Derivatives.yml
+++ b/core/Finance/ByKaranteli-Crypto-Derivatives.yml
@@ -1,0 +1,47 @@
+---
+title: ByKaranteli Crypto Derivatives Datasets - Funding, Open Interest, Liquidations, Options, ETF Flows and CFTC COT
+homepage: https://github.com/bykarantelicom/crypto-datasets
+category: Finance
+description: >-
+  Plain CSV and JSON datasets on cryptocurrency derivatives and market structure,
+  published in a public Git repository and refreshed daily by an automated export.
+  They cover weekly CFTC Commitments of Traders positioning for CME Bitcoin, Micro
+  Bitcoin, Ether and Micro Ether futures since 2018-04; daily Coinbase spot premium
+  (US close vs global close) for BTC and ETH since 2017-08; daily Deribit DVOL
+  implied volatility for BTC and ETH since 2021-03; daily US spot Bitcoin and Ether
+  ETF net inflow, net assets, cumulative inflow and value traded since 2025-05;
+  daily long and short liquidation totals per symbol and exchange recorded from the
+  public Binance, Bybit and OKX streams since 2026-07-30; a same-day Deribit BTC and
+  ETH options open-interest chain with instrument, expiry, strike, type, open
+  interest, mark IV and underlying price; a perpetual listing and delisting tracker
+  across six exchanges (Binance, OKX, Bybit, Gate, HTX, BingX); and daily market
+  aggregates (BTC and ETH dominance, total market cap, 24h volume, stablecoin cap,
+  Fear and Greed) plus per-symbol daily funding rate, 24h open-interest change and
+  24h price change for Binance USDT-M perpetuals. Every file downloads directly from
+  the repository with no login, no API key and no rate limit. Missing days are left
+  as gaps rather than interpolated.
+version:
+keywords: cryptocurrency, derivatives, perpetual futures, funding rate, open interest, liquidations, options, implied volatility, ETF flows, CFTC commitments of traders, market microstructure, csv, cc0
+image:
+temporal: 2017-08 / ongoing
+spatial: global
+access_level: public
+copyrights:
+accrual_periodicity: daily
+specification: https://github.com/bykarantelicom/crypto-datasets#datasets
+data_quality: false
+data_dictionary: https://github.com/bykarantelicom/crypto-datasets#datasets
+language: en
+license: CC0-1.0
+publisher:
+  - name: ByKaranteli
+    web: https://bykaranteli.com
+organization:
+  - name: ByKaranteli
+    web: https://bykaranteli.com
+issued_time: 2026.07
+sources:
+  - name: GitHub repository (CSV and JSON files)
+    access_url: https://github.com/bykarantelicom/crypto-datasets/tree/main/data
+  - name: ByKaranteli data hub
+    access_url: https://bykaranteli.com/data


### PR DESCRIPTION
### New data entry

`core/Finance/ByKaranteli-Crypto-Derivatives.yml` (one new file, nothing else touched).

- **title:** ByKaranteli Crypto Derivatives Datasets - Funding, Open Interest, Liquidations, Options, ETF Flows and CFTC COT
- **homepage:** https://github.com/bykarantelicom/crypto-datasets
- **category:** Finance (matches the folder name)
- **license:** CC0-1.0 (public domain dedication, `LICENSE` in the repo)
- **accrual_periodicity:** daily, by an automated export job

### What is in it

Plain CSV/JSON files, downloadable straight from the repository. No login, no API key, no purchase:

| File | Coverage |
| --- | --- |
| `cot-weekly.csv` | Weekly CFTC Commitments of Traders for CME Bitcoin, Micro Bitcoin, Ether and Micro Ether futures, from 2018-04 |
| `premium-daily.csv` | Coinbase spot premium (US close vs global close) for BTC and ETH, from 2017-08 |
| `dvol-daily.csv` | Deribit DVOL implied-volatility index for BTC and ETH, from 2021-03 |
| `etf-flows.csv` | US spot Bitcoin and Ether ETF net inflow, net assets, cumulative inflow, value traded, from 2025-05 |
| `liquidations-daily.csv` | Daily long/short liquidation totals per symbol and exchange, recorded from public Binance, Bybit and OKX streams, from 2026-07-30 |
| `options-oi-daily.csv` | Same-day Deribit BTC/ETH options open-interest chain (instrument, expiry, strike, type, OI, mark IV, underlying) |
| `listings.csv` | Perpetual listing/delisting tracker across Binance, OKX, Bybit, Gate, HTX and BingX |
| `daily-market.csv`, `daily-symbols.csv`, `indices-latest.json` | Daily market aggregates and per-symbol funding / open-interest change / price change for Binance USDT-M perpetuals |

### Against the quality criteria in CONTRIBUTING.md

- **Uncommon to obtain legally in the open community:** correcting myself here. An earlier revision of this description claimed these series are "normally behind paid analytics products". I cannot prove that and I have withdrawn it. The underlying inputs are public exchange and regulator endpoints, and anyone can pull them. What this entry actually offers is the *recorded* form: WebSocket-only liquidation events that are not replayable after the fact, plus multi-year backfills (COT from 2018-04, Coinbase premium from 2017-08, DVOL from 2021-03) kept as flat files with missing days left as gaps rather than interpolated. If that is not the kind of "uncommon" the criterion is asking for, tell me and I will withdraw the PR rather than argue it.
- **Valuable for a specific domain:** crypto derivatives and market-microstructure research.
- **Downloadable directly from the linked site:** yes, raw files in the repo, no login or purchase gate.
- **No advertisement:** the entry states what the data is and where it comes from. I maintain it, so please treat this as a self-submission.

### Checks I ran

- `python tests/validate.py` passes locally (`title`, `homepage`, `category` present; `category` equals the folder name).
- Keys and their order copied from `PULL_REQUEST_TEMPLATE.yml`.
- Searched `core/` for "bykaranteli": no existing entry.
- `homepage` returns HTTP 200 with no redirect, so `tools/check_urls.py` stays clean.
- Submitted here rather than to `awesome-public-datasets`, per the README/CONTRIBUTING flow.

The committed `.yml` was already free of that claim, so this correction is to the PR description only; the diff is unchanged.

No rush from my side: I saw the note that the primary maintainer is back on Aug 24.
