### PR TITLE
Add: Blackjack Basic Strategy with Per-Action EV (Entertainment)

### DIFF
--- a/core/Entertainment/blackjack-basic-strategy-per-action-ev.yml
+++ b/core/Entertainment/blackjack-basic-strategy-per-action-ev.yml
@@ -1,0 +1,9 @@
+---
+title: Blackjack Basic Strategy with Per-Action EV
+homepage: https://github.com/Blackjack-Verdict/blackjack-basic-strategy
+category: Entertainment
+description: >
+  All 340 blackjack basic-strategy decisions (hard/soft/pairs x dealer upcard),
+  each with the expected value of every available action (hit/stand/double/split,
+  per $1) and the win/push/lose split of the optimal play. CSV, CC BY 4.0,
+  zero-dependency Python loader with canonical tests included.


### PR DESCRIPTION
Adds a decision-level blackjack dataset: 340 cells with the EV of every action — a ready benchmark for decision-making/RL work (valuable domain knowledge). Directly downloadable CSV under CC BY 4.0, with a dependency-free loader and canonical tests. No paywall, no login.