### PR TITLE
Add GeoRank city climate and cost dataset (Climate+Weather)

### DIFF
--- a/core/Climate+Weather/GeoRank-City-Climate.yml
+++ b/core/Climate+Weather/GeoRank-City-Climate.yml
@@ -1,0 +1,22 @@
+---
+title: GeoRank City Climate and Cost Dataset
+homepage: https://georank.place/data/cities-tools.json
+category: Climate+Weather
+description: Monthly climate normals for 478 world cities - sunshine hours, mean and daytime-high temperature, rainfall, and a modelled outdoor-comfort index derived from apparent temperature - alongside Numbeo-based cost-of-living fields. Satellite sunshine (SARAH-3, 1991-2020) is bias-corrected against 219 published station normals, each listed with its source and normals period.
+version:
+keywords: climate, weather, sunshine, temperature, rainfall, cities, cost of living, apparent temperature
+image:
+temporal: 1981-2010 (temperature, CHELSA v2.1); 1991-2020 (sunshine, SARAH-3)
+spatial: 478 cities worldwide
+access_level: public
+copyrights: CC BY 4.0
+accrual_periodicity: irregular
+specification: single JSON file, no authentication, no rate limit
+data_quality: Sunshine bias-corrected against 219 WMO/KNMI/ECA&D reference stations; methodology and per-station provenance published at https://georank.place/methodology
+data_dictionary: https://georank.place/methodology
+language: en
+license: CC BY 4.0
+publisher: GeoRank
+organization:
+issued_time:
+sources: []


### PR DESCRIPTION
Adds a single entry under Climate+Weather.

**What it is:** monthly climate normals for 478 world cities — sunshine hours, mean and daytime-high temperature, rainfall, and a modelled outdoor-comfort index — with Numbeo-based cost-of-living fields alongside.

**Against the CONTRIBUTING criteria:**

- *Downloadable directly, not barred by login or purchasing* — one JSON file, no account, no key, no rate limit: https://georank.place/data/cities-tools.json
- *Contributing valuable knowledge for a specific domain* — the per-city monthly outdoor-comfort series (apparent temperature modelled half-hourly across daylight from temperature, humidity and wind) is not something I have found published elsewhere at this coverage.
- *Licensing* — CC BY 4.0.

**Provenance, since the list is for high-quality data:** sunshine is SARAH-3 satellite (1991–2020) bias-corrected against 219 published station normals, and every one of those stations is listed with its individual source and normals period at https://georank.place/methodology — so any figure can be traced back to the original WMO or national-service record.

**Disclosure:** I maintain this dataset. Two limitations are documented on the methodology page rather than buried: a small number of south-west Cyprus city-months read high because the correction is annual rather than monthly, and the rent fields are modelled from Numbeo's rent index rather than observed listing medians.

Happy to adjust the description or drop it if it is not a fit.