### PR TITLE
Add GeoCables Internet Latency & Routing Observations (ComputerNetworks)

### DIFF
--- a/core/ComputerNetworks/GeoCables-Internet-Latency-Observations.yml
+++ b/core/ComputerNetworks/GeoCables-Internet-Latency-Observations.yml
@@ -20,4 +20,3 @@ publisher: GeoCables
 organization: GeoCables
 issued_time:
 sources: []
----

--- a/core/ComputerNetworks/GeoCables-Internet-Latency-Observations.yml
+++ b/core/ComputerNetworks/GeoCables-Internet-Latency-Observations.yml
@@ -1,0 +1,23 @@
+---
+title: GeoCables Internet Latency & Routing Observations
+homepage: https://geocables.com/dataset
+category: ComputerNetworks
+description: Daily aggregated round-trip latency measured from an independent probe network, plus routing anomalies detected from those measurements. Vantage points include regions under-represented in public measurement datasets. CSV/JSON with manifest and checksums, updated daily.
+version:
+keywords: internet latency,network measurement,submarine cables,routing anomaly,RTT
+image:
+temporal: 2026-07/present
+spatial: Global
+access_level: public
+copyrights:
+accrual_periodicity: daily
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license: CC BY 4.0
+publisher: GeoCables
+organization: GeoCables
+issued_time:
+sources: []
+---


### PR DESCRIPTION
Adding an open dataset of internet latency measurements to core/ComputerNetworks.

- Daily aggregated round-trip latency from an independent probe network (median/p90/min per day, probe city, target), plus detected routing anomalies (3,400+ events).
- Vantage points include regions under-represented in public measurement data.
- CSV/JSON with manifest and checksums, regenerated daily at stable URLs. CC BY 4.0.
- Landing page: https://geocables.com/dataset