### PR TITLE
Add Football Betting Predictions - Fully Settled Public Log (Sports)

### DIFF
--- a/core/Sports/Football-Betting-Predictions-Fully-Settled-Log.yml
+++ b/core/Sports/Football-Betting-Predictions-Fully-Settled-Log.yml
@@ -1,0 +1,12 @@
+---
+title: Football Betting Predictions - Fully Settled Public Log
+homepage: https://www.kaggle.com/datasets/aibettingtips/football-betting-predictions-fully-settled-log
+category: Sports
+description: Football predictions archived before kick-off and settled against real final scores, losses included. Per pick - model probability, decimal odds at publication, closing odds and closing-line value, plus the matching final-score archive. Grows twice daily.
+keywords: football,soccer,betting,odds,predictions,closing-line-value
+access_level: public
+data_quality: true
+language: en
+license: CC BY 4.0
+publisher: AI Betting Tips
+sources: []


### PR DESCRIPTION
Adds a CC BY 4.0 Kaggle dataset: every football prediction we publish, archived pre-kick-off and auto-settled against real final scores — losing runs included. Columns cover model probability, odds at publication, closing odds and CLV; a companion CSV carries the final scores used for settlement. Updated twice daily.

Disclosure: I publish this dataset. Submitting it because fully settled prediction logs (losses included, with closing odds) are rare — most public tipster data suffers from survivorship bias.