### PR TITLE
Add West Georgia Auto Shop Review-Response Dataset

### DIFF
--- a/core/NaturalLanguage/West-Georgia-Auto-Shop-Review-Response-Dataset.yml
+++ b/core/NaturalLanguage/West-Georgia-Auto-Shop-Review-Response-Dataset.yml
@@ -1,0 +1,10 @@
+---
+title: West Georgia Auto Shop Review-Response Dataset
+homepage: https://doi.org/10.5281/zenodo.21899331
+category: NaturalLanguage
+description: Aggregated, per-shop metrics on how 68 independently owned and chain tire/auto-repair shops across five West Georgia counties (Carroll, Douglas, Paulding, Haralson, Heard) respond to Google reviews. Derived from a corpus of 5,716 Google reviews collected 2026-08-01, it reports per shop total and negative (1-2 star) review counts, star rating, reply rate to all reviews and to negative reviews (each with a 95% confidence interval), and a hand-graded breakdown of the 249 owner replies to negative reviews across four categories - apology, concrete remedy offered, generic/template language, and deflection. County-level benchmarks are included. No verbatim review text, reviewer-identifying information, or owner-reply text is included - derived/aggregate data only.
+keywords: online reviews, review response, customer service, small business, Google reviews, reputation management, auto repair, tire shops, Georgia, local business, text classification
+access_level: public
+license: CC-BY 4.0
+language: en
+issued_time: 2026


### PR DESCRIPTION
Adds a new data entry under core/NaturalLanguage for the West Georgia Auto Shop Review-Response Dataset.

Dataset: 5,716 Google reviews of 68 tire and auto-repair shops across five West Georgia counties, with per-shop reply rates and a hand-graded breakdown of 249 owner replies to negative reviews (apology, concrete remedy, generic/template, deflection), plus county-level benchmarks. No verbatim review text or reviewer-identifying information - derived/aggregate data only. Published on Zenodo under CC-BY 4.0 (canonical homepage/DOI used in the entry), with mirrors on Kaggle and Hugging Face.

Verified core/NaturalLanguage/West-Georgia-Auto-Shop-Review-Response-Dataset.yml passes tests/validate.py (required fields title, homepage, category present; category matches folder name).