### PR TITLE
Add StateCalc US Vehicle Registration Costs 2026

### DIFF
--- a/core/Transportation/StateCalc-US-Vehicle-Registration-Costs-2026.yml
+++ b/core/Transportation/StateCalc-US-Vehicle-Registration-Costs-2026.yml
@@ -1,9 +1,9 @@
 ---
 title: StateCalc US Vehicle Registration Costs 2026
-homepage: https://github.com/Pixels512/statecalc-open-data/tree/main/data/vehicle-registration-costs/2026-08-15.1
+homepage: https://github.com/Pixels512/statecalc-open-data/tree/main/data/vehicle-registration-costs/2026-08-15.2
 category: Transportation
-description: Versioned source-backed first-year vehicle registration, title, state purchase-tax and other fee data for the same $32,000 passenger car across 48 U.S. states. CSV and JSON include official source URLs and verification dates; two modeled states are excluded.
-version: 2026-08-15.1
+description: Versioned source-backed first-year vehicle registration, title, state purchase-tax and other fee data for the same $32,000 passenger car across 49 U.S. states. CSV and JSON include official source URLs and verification dates; one modeled state is excluded.
+version: 2026-08-15.2
 keywords: vehicle registration,title fees,purchase tax,DMV,United States
 image:
 temporal: 2026
@@ -13,7 +13,7 @@ copyrights:
 accrual_periodicity: irregular
 specification: Frictionless Data Package
 data_quality: true
-data_dictionary: https://github.com/Pixels512/statecalc-open-data/blob/main/data/vehicle-registration-costs/2026-08-15.1/datapackage.json
+data_dictionary: https://github.com/Pixels512/statecalc-open-data/blob/main/data/vehicle-registration-costs/2026-08-15.2/datapackage.json
 language: en
 license: CC-BY-4.0
 publisher:
@@ -23,9 +23,9 @@ organization:
 issued_time: 2026-08-15
 sources:
   - name: CSV distribution
-    access_url: https://raw.githubusercontent.com/Pixels512/statecalc-open-data/main/data/vehicle-registration-costs/2026-08-15.1/vehicle-registration-costs.csv
+    access_url: https://raw.githubusercontent.com/Pixels512/statecalc-open-data/main/data/vehicle-registration-costs/2026-08-15.2/vehicle-registration-costs.csv
   - name: JSON distribution
-    access_url: https://raw.githubusercontent.com/Pixels512/statecalc-open-data/main/data/vehicle-registration-costs/2026-08-15.1/vehicle-registration-costs.json
+    access_url: https://raw.githubusercontent.com/Pixels512/statecalc-open-data/main/data/vehicle-registration-costs/2026-08-15.2/vehicle-registration-costs.json
 references:
   - title: Methodology, provenance and citation
     reference: https://github.com/Pixels512/statecalc-open-data/blob/main/README.md

--- a/core/Transportation/StateCalc-US-Vehicle-Registration-Costs-2026.yml
+++ b/core/Transportation/StateCalc-US-Vehicle-Registration-Costs-2026.yml
@@ -1,9 +1,9 @@
 ---
 title: StateCalc US Vehicle Registration Costs 2026
-homepage: https://github.com/Pixels512/statecalc-open-data/tree/main/data/vehicle-registration-costs/2026-08-15.2
+homepage: https://github.com/Pixels512/statecalc-open-data/tree/main/data/vehicle-registration-costs/2026-08-15.3
 category: Transportation
 description: Versioned source-backed first-year vehicle registration, title, state purchase-tax and other fee data for the same $32,000 passenger car across 49 U.S. states. CSV and JSON include official source URLs and verification dates; one modeled state is excluded.
-version: 2026-08-15.2
+version: 2026-08-15.3
 keywords: vehicle registration,title fees,purchase tax,DMV,United States
 image:
 temporal: 2026
@@ -13,7 +13,7 @@ copyrights:
 accrual_periodicity: irregular
 specification: Frictionless Data Package
 data_quality: true
-data_dictionary: https://github.com/Pixels512/statecalc-open-data/blob/main/data/vehicle-registration-costs/2026-08-15.2/datapackage.json
+data_dictionary: https://github.com/Pixels512/statecalc-open-data/blob/main/data/vehicle-registration-costs/2026-08-15.3/datapackage.json
 language: en
 license: CC-BY-4.0
 publisher:
@@ -23,9 +23,9 @@ organization:
 issued_time: 2026-08-15
 sources:
   - name: CSV distribution
-    access_url: https://raw.githubusercontent.com/Pixels512/statecalc-open-data/main/data/vehicle-registration-costs/2026-08-15.2/vehicle-registration-costs.csv
+    access_url: https://raw.githubusercontent.com/Pixels512/statecalc-open-data/main/data/vehicle-registration-costs/2026-08-15.3/vehicle-registration-costs.csv
   - name: JSON distribution
-    access_url: https://raw.githubusercontent.com/Pixels512/statecalc-open-data/main/data/vehicle-registration-costs/2026-08-15.2/vehicle-registration-costs.json
+    access_url: https://raw.githubusercontent.com/Pixels512/statecalc-open-data/main/data/vehicle-registration-costs/2026-08-15.3/vehicle-registration-costs.json
 references:
   - title: Methodology, provenance and citation
     reference: https://github.com/Pixels512/statecalc-open-data/blob/main/README.md

--- a/core/Transportation/StateCalc-US-Vehicle-Registration-Costs-2026.yml
+++ b/core/Transportation/StateCalc-US-Vehicle-Registration-Costs-2026.yml
@@ -1,0 +1,31 @@
+---
+title: StateCalc US Vehicle Registration Costs 2026
+homepage: https://github.com/Pixels512/statecalc-open-data/tree/main/data/vehicle-registration-costs/2026-08-15.1
+category: Transportation
+description: Versioned source-backed first-year vehicle registration, title, state purchase-tax and other fee data for the same $32,000 passenger car across 48 U.S. states. CSV and JSON include official source URLs and verification dates; two modeled states are excluded.
+version: 2026-08-15.1
+keywords: vehicle registration,title fees,purchase tax,DMV,United States
+image:
+temporal: 2026
+spatial: United States
+access_level: public
+copyrights:
+accrual_periodicity: irregular
+specification: Frictionless Data Package
+data_quality: true
+data_dictionary: https://github.com/Pixels512/statecalc-open-data/blob/main/data/vehicle-registration-costs/2026-08-15.1/datapackage.json
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: StateCalc
+    web: https://github.com/Pixels512/statecalc-open-data
+organization:
+issued_time: 2026-08-15
+sources:
+  - name: CSV distribution
+    access_url: https://raw.githubusercontent.com/Pixels512/statecalc-open-data/main/data/vehicle-registration-costs/2026-08-15.1/vehicle-registration-costs.csv
+  - name: JSON distribution
+    access_url: https://raw.githubusercontent.com/Pixels512/statecalc-open-data/main/data/vehicle-registration-costs/2026-08-15.1/vehicle-registration-costs.json
+references:
+  - title: Methodology, provenance and citation
+    reference: https://github.com/Pixels512/statecalc-open-data/blob/main/README.md

--- a/core/Transportation/StateCalc-US-Vehicle-Registration-Costs-2026.yml
+++ b/core/Transportation/StateCalc-US-Vehicle-Registration-Costs-2026.yml
@@ -1,9 +1,9 @@
 ---
 title: StateCalc US Vehicle Registration Costs 2026
-homepage: https://github.com/Pixels512/statecalc-open-data/tree/main/data/vehicle-registration-costs/2026-08-15.3
+homepage: https://github.com/Pixels512/statecalc-open-data/tree/main/data/vehicle-registration-costs/2026-08-16.1
 category: Transportation
 description: Versioned source-backed first-year vehicle registration, title, state purchase-tax and other fee data for the same $32,000 passenger car across 49 U.S. states. CSV and JSON include official source URLs and verification dates; one modeled state is excluded.
-version: 2026-08-15.3
+version: 2026-08-16.1
 keywords: vehicle registration,title fees,purchase tax,DMV,United States
 image:
 temporal: 2026
@@ -13,19 +13,19 @@ copyrights:
 accrual_periodicity: irregular
 specification: Frictionless Data Package
 data_quality: true
-data_dictionary: https://github.com/Pixels512/statecalc-open-data/blob/main/data/vehicle-registration-costs/2026-08-15.3/datapackage.json
+data_dictionary: https://github.com/Pixels512/statecalc-open-data/blob/main/data/vehicle-registration-costs/2026-08-16.1/datapackage.json
 language: en
 license: CC-BY-4.0
 publisher:
   - name: StateCalc
     web: https://github.com/Pixels512/statecalc-open-data
 organization:
-issued_time: 2026-08-15
+issued_time: 2026-08-16
 sources:
   - name: CSV distribution
-    access_url: https://raw.githubusercontent.com/Pixels512/statecalc-open-data/main/data/vehicle-registration-costs/2026-08-15.3/vehicle-registration-costs.csv
+    access_url: https://raw.githubusercontent.com/Pixels512/statecalc-open-data/main/data/vehicle-registration-costs/2026-08-16.1/vehicle-registration-costs.csv
   - name: JSON distribution
-    access_url: https://raw.githubusercontent.com/Pixels512/statecalc-open-data/main/data/vehicle-registration-costs/2026-08-15.3/vehicle-registration-costs.json
+    access_url: https://raw.githubusercontent.com/Pixels512/statecalc-open-data/main/data/vehicle-registration-costs/2026-08-16.1/vehicle-registration-costs.json
 references:
   - title: Methodology, provenance and citation
     reference: https://github.com/Pixels512/statecalc-open-data/blob/main/README.md


### PR DESCRIPTION
## Dataset

Updates **StateCalc US Vehicle Registration Costs 2026** to version
`2026-08-16.1`.

- 49 source-backed U.S. state rows; Alaska remains excluded while modeled.
- Corrects Oregon's up-front initial-registration total by modeling the
  standard two-year term and four-year MCO term for a new passenger vehicle.
- Only registration and county surcharges scale with the selected Oregon term;
  title, plates, and vehicle privilege tax remain one-time charges.
- Same $32,000 reference passenger car for comparable annual registration,
  title, state purchase tax, other first-year fees and total.
- CSV + JSON + Frictionless datapackage + SHA-256 checksums.
- CC BY 4.0, no signup, no payment, direct downloads.
- Every row includes an official source URL and verification date.

## Disclosure

I represent StateCalc, the dataset publisher. StateCalc is a commercial
calculator site, but this public data-only mirror and all release files are
free. This submission is for the dataset's transportation-policy utility, not
for reputation promotion. No other awesome-list submissions are being made in
parallel.

The StateCalc site contains advertising, so it is deliberately not used as the
APD homepage, publisher link, reference, or distribution URL. Every URL in the
catalog entry points to an ad-free GitHub repository or raw GitHub file.

Versioned mirror:
https://github.com/Pixels512/statecalc-open-data/tree/main/data/vehicle-registration-costs/2026-08-16.1

Immutable release:
https://github.com/Pixels512/statecalc-open-data/releases/tag/vehicle-registration-costs-v2026.08.16.1