### PR TITLE
Update Detourmap dataset entry to the current download (40,703 places, 231 countries)

### DIFF
--- a/core/GIS/World-Notable-Places-Detourmap.yml
+++ b/core/GIS/World-Notable-Places-Detourmap.yml
@@ -2,7 +2,7 @@
 title: World Notable Places (Detourmap)
 homepage: https://detourmap.com/data/
 category: GIS
-description: 40,703 notable places worth a detour worldwide — natural wonders and archaeological sites: waterfalls, caves, volcanoes, gorges and coves, plus ruins, tombs, ghost towns, shipwrecks, catacombs and mines across 231 countries and territories, each with coordinates, kind, founding year, fame rank, a photo and an English Wikipedia link. Selection is deterministic from Wikidata classes (no editorial or AI-generated content); fame rank comes from Wikidata sitelink counts. Direct CSV and GeoJSON downloads, no login required. Note: the archived snapshots linked below predate an August 2026 narrowing and carry a wider cut of ~71.8k places that also included castles, churches, museums and gardens.
+description: 40,703 notable places worth a detour worldwide — natural wonders and archaeological sites, from waterfalls, caves, volcanoes, gorges and coves to ruins, tombs, ghost towns, shipwrecks, catacombs and mines — across 231 countries and territories, each with coordinates, kind, founding year, fame rank, a photo and an English Wikipedia link. Selection is deterministic from Wikidata classes (no editorial or AI-generated content); fame rank comes from Wikidata sitelink counts. Direct CSV and GeoJSON downloads, no login required. Note that the archived snapshots linked below predate an August 2026 narrowing and carry a wider cut of ~71.8k places that also included castles, churches, museums and gardens.
 version: 1.0.0
 keywords: points of interest, landmarks, travel, tourism, geography, geojson, wikidata, open data
 image:

--- a/core/GIS/World-Notable-Places-Detourmap.yml
+++ b/core/GIS/World-Notable-Places-Detourmap.yml
@@ -2,12 +2,12 @@
 title: World Notable Places (Detourmap)
 homepage: https://detourmap.com/data/
 category: GIS
-description: 70,343 notable places worth a detour worldwide — ancient sites, waterfalls, caves, castles, museums, ghost towns and more across 348 countries and territories, each with coordinates, kind, founding year, fame rank, a photo and an English Wikipedia link. Selection is deterministic from ~50 Wikidata classes (no editorial or AI-generated content); fame rank comes from Wikidata sitelink counts. Direct CSV and GeoJSON downloads, no login required.
+description: 40,703 notable places worth a detour worldwide — natural wonders and archaeological sites: waterfalls, caves, volcanoes, gorges and coves, plus ruins, tombs, ghost towns, shipwrecks, catacombs and mines across 231 countries and territories, each with coordinates, kind, founding year, fame rank, a photo and an English Wikipedia link. Selection is deterministic from Wikidata classes (no editorial or AI-generated content); fame rank comes from Wikidata sitelink counts. Direct CSV and GeoJSON downloads, no login required. Note: the archived snapshots linked below predate an August 2026 narrowing and carry a wider cut of ~71.8k places that also included castles, churches, museums and gardens.
 version: 1.0.0
 keywords: points of interest, landmarks, travel, tourism, geography, geojson, wikidata, open data
 image:
 temporal:
-spatial: worldwide (348 countries and territories)
+spatial: worldwide (231 countries and territories)
 access_level: public
 copyrights:
 accrual_periodicity: irregular


### PR DESCRIPTION
Thanks for merging this entry in July (#498). This updates it to match what the linked homepage actually serves today.

The site behind the dataset was narrowed on 16 August to two layers, natural wonders and archaeological sites. Castles, churches, museums, gardens and theme parks were dropped, so the CSV and GeoJSON at the listed homepage are now 40,703 places across 231 countries, not 70,343 across 348.

The description also now says plainly that the archived Zenodo and GitHub snapshots linked in the entry predate that change and still carry the wider cut, so anyone comparing the two files knows why the counts differ.
