### PR TITLE
Castles of the World: update to 7,044 records across 141 countries

### DIFF
--- a/core/GIS/Castles-of-the-World.yml
+++ b/core/GIS/Castles-of-the-World.yml
@@ -2,12 +2,12 @@
 title: Castles of the World
 homepage: https://thecastlemap.com/data/
 category: GIS
-description: 2,400 documented castles, fortresses and palaces across 131 countries — name, type (castle/palace/fortress/ruin), country, coordinates, founding year and century, image and Wikipedia/Wikidata links. Curated from Wikidata and hand-checked. Direct GeoJSON and CSV downloads, no login required.
-version: 1.0
+description: 7,044 documented castles, fortresses and palaces across 141 countries — name, type (castle/palace/fortress/ruin), country, coordinates, founding year and century, image with photographer and licence, and Wikipedia/Wikidata links. Curated from Wikidata and hand-checked. Direct GeoJSON and CSV downloads, no login required.
+version: 2.0
 keywords: castles, palaces, fortresses, medieval, heritage, landmarks, geojson, wikidata
 image:
 temporal:
-spatial: worldwide (131 countries)
+spatial: worldwide (141 countries)
 access_level: public
 copyrights:
 accrual_periodicity: irregular
@@ -22,7 +22,7 @@ publisher:
 organization:
   - name:
     web:
-issued_time: 2026.07
+issued_time: 2026.08
 sources:
   - name: Wikidata
     access_url: https://www.wikidata.org


### PR DESCRIPTION
Metadata refresh for an existing GIS entry. The dataset has grown since it was added in July: 2,400 records across 131 countries then, 7,044 across 141 now. The downloads at the same URL are already current, so only the description was out of date.

Changed in `core/GIS/Castles-of-the-World.yml`:

- record count and country count in `description` and `spatial`
- `version` 1.0 -> 2.0, `issued_time` 2026.07 -> 2026.08
- description now mentions the photographer and licence fields, which were added to both exports on 2026-08-08

Still CC0, still a direct GeoJSON/CSV download with no login: https://thecastlemap.com/data/

Disclosure: I maintain the dataset. Noted that the primary maintainer is away until Aug 24 — no rush.