### PR TITLE
Add HDD Price Index dataset (Economics)

### DIFF
--- a/core/Economics/HDD-Price-Index.yml
+++ b/core/Economics/HDD-Price-Index.yml
@@ -1,0 +1,44 @@
+---
+title: HDD Price Index
+homepage: https://github.com/AdamDudley/hddhunt-price-index
+category: Economics
+description: An open dataset tracking the cheapest new internal 3.5" SATA hard-drive
+  price per terabyte (USD/TB) at each capacity tier (4TB-24TB) on Amazon.com (US).
+  Each snapshot surveys ~1,150 new-HDD listings out of a ~8,500-listing catalogue and
+  records, per tier, the single cheapest usable drive by $/TB (SAS server pulls and
+  USB externals excluded). Aggregated into a dated snapshot plus an append-only daily
+  time series of the full per-tier price curve. Delivered as CSV and JSONL, downloadable
+  directly without login, and reproducible via a public no-auth PostgREST API over the
+  underlying listings.
+version: 1.0
+keywords: hard drive, HDD, storage, pricing, price index, price per terabyte, cost per TB, time series, Amazon
+image:
+temporal: 2026-present
+spatial: US (Amazon.com)
+access_level: public
+copyrights: CC BY 4.0
+accrual_periodicity: daily
+specification: https://github.com/AdamDudley/hddhunt-price-index#readme
+data_quality: true
+data_dictionary: https://github.com/AdamDudley/hddhunt-price-index#columns-csv
+language: en
+license: CC BY 4.0
+publisher:
+  - name: HDDHunt
+    web: https://hddhunt.com/
+organization:
+  - name: HDDHunt
+    web: https://github.com/AdamDudley/hddhunt-price-index
+issued_time: 2026.08
+sources:
+  - name: Latest snapshot (CSV, one row per capacity tier)
+    access_url: https://raw.githubusercontent.com/AdamDudley/hddhunt-price-index/main/price-index-latest.csv
+  - name: Daily time series (JSONL, full per-tier $/TB curve)
+    access_url: https://raw.githubusercontent.com/AdamDudley/hddhunt-price-index/main/price-index-timeseries.jsonl
+  - name: Underlying listings API (public, no-auth PostgREST)
+    access_url: https://postgrest.hddhunt.com/drives
+references:
+  - title: Methodology and column dictionary
+    reference: https://github.com/AdamDudley/hddhunt-price-index#methodology
+  - title: Dataset license (CC BY 4.0)
+    reference: https://github.com/AdamDudley/hddhunt-price-index/blob/main/LICENSE

--- a/core/Economics/HDD-Price-Index.yml
+++ b/core/Economics/HDD-Price-Index.yml
@@ -12,7 +12,6 @@ description: An open dataset tracking the cheapest new internal 3.5" SATA hard-d
   underlying listings.
 version: 1.0
 keywords: hard drive, HDD, storage, pricing, price index, price per terabyte, cost per TB, time series, Amazon
-image:
 temporal: 2026-present
 spatial: US (Amazon.com)
 access_level: public


### PR DESCRIPTION
Adds one new dataset entry: **HDD Price Index** under `core/Economics/`.

**What it is:** an open dataset tracking the cheapest *new internal 3.5" SATA* hard-drive price per terabyte (USD/TB) at each capacity tier (4TB–24TB) on Amazon.com (US), aggregated into a dated snapshot plus an append-only daily time series of the full per-tier price curve.

**Meets the quality bar:**
- **Downloadable directly, no login/purchase** — CSV + JSONL served as raw files:
  - https://raw.githubusercontent.com/AdamDudley/hddhunt-price-index/main/price-index-latest.csv
  - https://raw.githubusercontent.com/AdamDudley/hddhunt-price-index/main/price-index-timeseries.jsonl
- **Reproducible** — underlying listings exposed via a public no-auth PostgREST API (`https://postgrest.hddhunt.com/drives`); the README documents the exact query.
- **Open license** — CC BY 4.0.
- Dataset repo (homepage): https://github.com/AdamDudley/hddhunt-price-index

Follows the same shape as the existing `Cloud-GPU-Price-Index` and `Shortlist-Price-Index` entries. Validated locally with `./tests/testing.sh` (passes). One entry, one PR.