### PR TITLE
Add Filming Locations of the World (15,272 places, 12,762 productions, CC0)

### DIFF
--- a/core/GIS/Filming-Locations-of-the-World.yml
+++ b/core/GIS/Filming-Locations-of-the-World.yml
@@ -1,0 +1,31 @@
+---
+title: Filming Locations of the World
+homepage: https://thefilmmap.com/data/
+category: GIS
+description: 15,272 real filming locations across 161 countries, joined to the 12,762 films, series, video games, anime and manga recorded at them. Per place, name, kind, country, coordinates, fame rank and production counts; per production, kind, years, the places attached to it and what each claim was read from. Films and series are placed by filming location (P915); games, anime and manga are filmed nowhere and are placed by narrative location (P840), and every row carries which relation it is. Built from Wikidata. Direct GeoJSON and CSV downloads, no login required.
+version: 1.0
+keywords: film, television, video games, anime, filming locations, cinema, geojson, wikidata
+image:
+temporal:
+spatial: worldwide (161 countries)
+access_level: public
+copyrights:
+accrual_periodicity: irregular
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license: CC0 1.0
+publisher:
+  - name: FilmMap
+    web: https://thefilmmap.com
+organization:
+  - name:
+    web:
+issued_time: 2026.08
+sources:
+  - name: Wikidata
+    access_url: https://www.wikidata.org
+references:
+  - title: Dataset repository on GitHub
+    reference: https://github.com/Flightmussy/filmmap-dataset


### PR DESCRIPTION
Where films, television series, video games, anime and manga were actually made: **15,272 real places across 161 countries**, joined to the **12,762 productions** recorded at them. GeoJSON and CSV, CC0, no login.

- Dataset page and downloads: https://thefilmmap.com/data/
- Repository: https://github.com/Flightmussy/filmmap-dataset
- The map it is behind: https://thefilmmap.com

Built from Wikidata. Per place: name, kind, country, WGS84 coordinates, fame rank, and production counts split by which evidence stream attached them. Per production: kind, years, the places it is attached to, and what exactly each Wikipedia claim was read from.

One distinction the file keeps and that anyone reusing it needs: films and series are placed by `filming location` (P915), while games, anime and manga are filmed nowhere and are placed by `narrative location` (P840). Every row carries the relation, so the two cannot be silently merged.

New `.yml` in `core/GIS/` only; the generated README is untouched.