### PR TITLE
Add Pakistan Fuel Prices (OGRA) to Energy

### DIFF
--- a/core/Energy/PakistanFuelPrices.yml
+++ b/core/Energy/PakistanFuelPrices.yml
@@ -1,8 +1,8 @@
 ---
-title: Pakistan Fuel Prices - official OGRA petrol, diesel, kerosene and LPG rates
+title: Pakistan Fuel Prices
 homepage: https://github.com/quantanow/pakistan-fuel-prices
 category: Energy
-description: Retail fuel prices for Pakistan as notified by the Oil and Gas Regulatory Authority (OGRA), parsed from the official price notification PDFs and updated within minutes of each new notification. Covers motor spirit (petrol 92 RON), high speed diesel, superior kerosene oil and LPG, in JSON and CSV, with the OGRA document id on every record so any price can be traced back to the notification it came from. The series do not share a start date - kerosene reaches back to 2015, LPG to 2022, petrol and diesel cover recent notifications only. A free keyless JSON API with CORS enabled serves the same data at https://oilprices.pk/fuel-price-api-pakistan.
+description: Retail fuel prices for Pakistan as notified by the Oil and Gas Regulatory Authority (OGRA), parsed from the official price notification PDFs. Covers motor spirit (petrol 92 RON), high speed diesel, superior kerosene oil and LPG in JSON and CSV, with the OGRA document id on every record so any price traces back to the notification it came from. The series do not share a start date - kerosene reaches back to 2015, LPG to 2022, petrol and diesel cover recent notifications only.
 version:
 keywords: fuel prices, petrol, diesel, kerosene, LPG, Pakistan, OGRA, energy prices, retail prices
 image:
@@ -20,7 +20,12 @@ publisher:
   - name: OilPrices.pk
     web: https://oilprices.pk
 organization:
-issued_time:
-sources:
   - name: Oil and Gas Regulatory Authority (OGRA)
     web: https://www.ogra.org.pk
+issued_time: 2026.08
+sources:
+  - name: Pakistan Fuel Prices dataset (JSON and CSV)
+    access_url: https://github.com/quantanow/pakistan-fuel-prices
+references:
+  - title: OGRA price notifications
+    reference: https://www.ogra.org.pk

--- a/core/Energy/PakistanFuelPrices.yml
+++ b/core/Energy/PakistanFuelPrices.yml
@@ -1,0 +1,26 @@
+---
+title: Pakistan Fuel Prices - official OGRA petrol, diesel, kerosene and LPG rates
+homepage: https://github.com/quantanow/pakistan-fuel-prices
+category: Energy
+description: Retail fuel prices for Pakistan as notified by the Oil and Gas Regulatory Authority (OGRA), parsed from the official price notification PDFs and updated within minutes of each new notification. Covers motor spirit (petrol 92 RON), high speed diesel, superior kerosene oil and LPG, in JSON and CSV, with the OGRA document id on every record so any price can be traced back to the notification it came from. The series do not share a start date - kerosene reaches back to 2015, LPG to 2022, petrol and diesel cover recent notifications only. A free keyless JSON API with CORS enabled serves the same data at https://oilprices.pk/fuel-price-api-pakistan.
+version:
+keywords: fuel prices, petrol, diesel, kerosene, LPG, Pakistan, OGRA, energy prices, retail prices
+image:
+temporal: 2015-07-01/ongoing
+spatial: Pakistan
+access_level: public
+copyrights:
+accrual_periodicity: daily
+specification:
+data_quality: false
+data_dictionary: https://oilprices.pk/fuel-price-api-pakistan
+language: en
+license: CC BY 4.0
+publisher:
+  - name: OilPrices.pk
+    web: https://oilprices.pk
+organization:
+issued_time:
+sources:
+  - name: Oil and Gas Regulatory Authority (OGRA)
+    web: https://www.ogra.org.pk


### PR DESCRIPTION
Adds a dataset of official Pakistani retail fuel prices — petrol, diesel, kerosene and LPG — as notified by the Oil and Gas Regulatory Authority (OGRA).

**Dataset:** https://github.com/quantanow/pakistan-fuel-prices
**API / docs:** https://oilprices.pk/fuel-price-api-pakistan

- Parsed from OGRA's official price notification PDFs, updated within minutes of each new notification.
- JSON and CSV. Every record carries OGRA's own document id, so any price traces back to the notification it came from.
- Licence: CC BY 4.0. The underlying notifications are public government documents.
- Free, keyless JSON API with CORS enabled for the same data.

Coverage is stated per product rather than as one range, because the four series genuinely differ: kerosene reaches 2015-07-01, LPG 2022-03-01, and petrol and diesel hold recent notifications only. The README in the dataset repo regenerates that table from the data on every update, so it cannot drift.

Added as `core/Energy/PakistanFuelPrices.yml`, following the schema used by the existing Energy entries.