### PR TITLE
Update State of ATS 2026 entry: correct row counts and remove an inaccurate claim

### DIFF
--- a/core/Economics/State-of-ATS-2026.yml
+++ b/core/Economics/State-of-ATS-2026.yml
@@ -2,15 +2,15 @@
 title: State of ATS 2026
 homepage: https://github.com/Kayvan-Zahiri/state-of-ats-2026
 category: Economics
-description: Hand-verified open dataset of which Applicant Tracking System (ATS) each of the 743 largest employers uses, covering the Fortune 500, Global 2000, and Series-C+ private companies valued at $1B or more. Useful for job seekers tailoring resumes per ATS family, HR and recruiting researchers, and anyone studying enterprise SaaS market share. Distributed as a raw CSV and as an npm package (@withresumeai/ats-data).
-version: 1.0
+description: Open dataset of which Applicant Tracking System (ATS) each of 738 large employers uses, covering the Fortune 500, Global 2000, and Series-C+ private companies valued at $1B or more. 704 rows are verified against the employer's live careers-portal apply host, and 551 publish that host so any row can be checked in a browser; provenance is recorded per row. Useful for job seekers tailoring resumes per ATS family, HR and recruiting researchers, and anyone studying enterprise SaaS market share. Distributed as a raw CSV and as an npm package (@withresumeai/ats-data).
+version: 1.4
 keywords: applicant tracking system, ATS, recruiting, HR tech, enterprise SaaS, market share, Fortune 500, Global 2000, employment, labor market, hiring
 image:
 temporal: 2026
 spatial: global
 access_level: public
 copyrights: MIT License
-accrual_periodicity: annually
+accrual_periodicity: monthly
 specification:
 data_quality: true
 data_dictionary: https://github.com/Kayvan-Zahiri/state-of-ats-2026#schema


### PR DESCRIPTION
I maintain this dataset. Correcting my own entry — the description overstates what the data is.

**"Hand-verified" is not accurate** and I would rather not have it on a listing this widely mirrored. Provenance in the dataset is mixed and recorded per row: most apply hosts were captured by automated careers-portal and vendor probes, and only 47 of 738 rows were recorded by a person working through the apply flow. The honest claim is that rows are *verified against the live careers portal*, which is true of 704 of them, and that 551 publish the host an application actually lands on so anyone can check a row in a browser.

**743 → 738.** Five duplicate rows were merged out.

Also bumped `accrual_periodicity` from `annually` to `monthly`, which reflects the actual re-probe cadence, and `version` to 1.4.

No change to the homepage, licence, sources or category.