### PR TITLE
Add Wiseek Filing Impact dataset (Finance)

### DIFF
--- a/core/Finance/Wiseek Filing Impact.yml
+++ b/core/Finance/Wiseek Filing Impact.yml
@@ -1,0 +1,30 @@
+---
+title: Wiseek Filing Impact
+homepage: https://wiseek.ai/datasets/
+category: Finance
+description: Monthly statistics on how SEC filings move US stocks. Importance scores (1-10) assigned in real time before the market reacts, versus measured next-session excess price moves, split by filing type, sentiment and market cap. Includes a per-event archive (ticker, company, form, score, outcome) and a written reproduction recipe; every aggregate cell reproduces from the public files. CC BY 4.0, DOI 10.5281/zenodo.22047734.
+version: 1.0
+keywords: sec, filings, event study, stock market, market reaction, 8-K, disclosure
+image:
+temporal: 2026-07-24 onward, monthly
+access_level: public
+copyrights: CC BY 4.0
+accrual_periodicity: monthly
+specification:
+data_quality: true
+data_dictionary: https://github.com/WiseekAI/wiseek-datasets#files-per-release-datarelease
+language: en
+publisher:
+  - name: Wiseek
+    web: https://wiseek.ai
+organization:
+  - name: Wiseek
+    web: https://wiseek.ai
+sources:
+  - name: Wiseek Datasets
+    access_url: https://wiseek.ai/datasets/
+  - name: GitHub mirror
+    access_url: https://github.com/WiseekAI/wiseek-datasets
+references:
+  - title: Zenodo archive (DOI)
+    reference: https://doi.org/10.5281/zenodo.22047734

--- a/core/Finance/Wiseek Filing Impact.yml
+++ b/core/Finance/Wiseek Filing Impact.yml
@@ -1,9 +1,9 @@
 ---
 title: Wiseek Filing Impact
-homepage: https://wiseek.ai/datasets/
+homepage: https://zenodo.org/records/22047734
 category: Finance
-description: Monthly statistics on how SEC filings move US stocks. Importance scores (1-10) assigned in real time before the market reacts, versus measured next-session excess price moves, split by filing type, sentiment and market cap. Includes a per-event archive (ticker, company, form, score, outcome) and a written reproduction recipe; every aggregate cell reproduces from the public files. CC BY 4.0, DOI 10.5281/zenodo.22047734.
-version: 1.0
+description: Monthly statistics on how SEC filings move US stocks. Importance scores (1-10) assigned in real time before the market reacts, versus measured next-session excess price moves, split by filing type, sentiment and market cap. Includes a per-event archive (ticker, company, form, score, outcome) and a written reproduction recipe; every aggregate cell reproduces from the public files. CC BY 4.0, DOI 10.5281/zenodo.22047734 (the homepage link resolves to the latest version with direct CSV/JSON downloads).
+version: 2026-08
 keywords: sec, filings, event study, stock market, market reaction, 8-K, disclosure
 image:
 temporal: 2026-07-24 onward, monthly
@@ -14,16 +14,20 @@ specification:
 data_quality: true
 data_dictionary: https://github.com/WiseekAI/wiseek-datasets#files-per-release-datarelease
 language: en
+license: CC BY 4.0
 publisher:
   - name: Wiseek
     web: https://wiseek.ai
 organization:
   - name: Wiseek
     web: https://wiseek.ai
+issued_time: 2026-08-21
 sources:
-  - name: Wiseek Datasets
+  - name: Zenodo archive (all versions, direct downloads)
+    access_url: https://zenodo.org/records/22047734
+  - name: Wiseek Datasets (canonical release pages + open JSON API)
     access_url: https://wiseek.ai/datasets/
-  - name: GitHub mirror
+  - name: GitHub mirror (checksummed)
     access_url: https://github.com/WiseekAI/wiseek-datasets
 references:
   - title: Zenodo archive (DOI)


### PR DESCRIPTION
Adds the Wiseek Filing Impact dataset: free monthly statistics on how SEC filings move US stocks (real-time importance scores vs measured next-session excess moves), with a per-event archive and full reproducibility (CC BY 4.0, DOI 10.5281/zenodo.22047734). Canonical: https://wiseek.ai/datasets/ | Mirror: https://github.com/WiseekAI/wiseek-datasets

Disclosure: I run Wiseek; the dataset itself is free and openly licensed.