### PR TITLE
Add Databook (SocialSciences) and Logibook (Transportation)

### DIFF
--- a/core/SocialSciences/Databook-Country-Indicators.yml
+++ b/core/SocialSciences/Databook-Country-Indicators.yml
@@ -1,0 +1,38 @@
+---
+title: Databook Country Indicators
+homepage: https://databook.dataint.net/
+category: SocialSciences
+description: Per-country reference profiles consolidating public statistical
+  indicators for 244 countries and territories, drawn from 108 openly licensed
+  datasets including World Bank WDI, WHO Global Health Observatory, UNESCO UIS,
+  UN DESA World Population Prospects and the CIA World Factbook. Each country is
+  covered across 15 sections (population, economy, health, education, labour,
+  governance, environment and energy, infrastructure, geography and others), and
+  every figure is shown with its source and reference year. Browse-only - no
+  registration, no paywall, no API or bulk download. Published in 25 languages.
+version: 2026
+keywords: country profiles,indicators,statistics,World Bank,WHO,UNESCO,reference data
+image:
+temporal: varies by indicator, most recent available year
+spatial: Global, 244 countries and territories
+access_level: public
+copyrights:
+accrual_periodicity: annual
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license: Source datasets under their own open licences; see the licensing page
+publisher:
+  - name: DataInt
+    web: https://dataint.net
+organization:
+  - name: DataInt
+    web: https://dataint.net
+issued_time: 2026
+sources:
+  - name: Sources and licences
+    access_url: https://databook.dataint.net/en/sources/
+references:
+  - title:
+    reference:

--- a/core/Transportation/Logibook-Trade-Logistics-Reference.yml
+++ b/core/Transportation/Logibook-Trade-Logistics-Reference.yml
@@ -1,0 +1,40 @@
+---
+title: Logibook Trade and Logistics Reference
+homepage: https://logibook.dataint.net/
+category: Transportation
+description: Per-country trade and logistics reference profiles for 250 countries
+  and territories, built from 98 openly licensed datasets including the NGA World
+  Port Index, OurAirports, UN/LOCODE, SMDG code lists, UNCTAD liner shipping
+  connectivity, the World Bank Logistics Performance Index and CEPII BACI. Each
+  country breaks down into seven views (ports, airports, locations, trade, trade
+  zones, airlines and infrastructure), joining registries that are normally
+  published separately, so a port page also carries its nearest airport, city and
+  trade zone with distances. Every figure is shown with its source and reference
+  year. Browse-only - no registration, no paywall, no API or bulk download.
+  Published in 25 languages.
+version: 2026
+keywords: ports,airports,UN/LOCODE,logistics,trade,shipping,reference data
+image:
+temporal: varies by registry, most recent available edition
+spatial: Global, 250 countries and territories
+access_level: public
+copyrights:
+accrual_periodicity: annual
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license: Source datasets under their own open licences; see the licensing page
+publisher:
+  - name: DataInt
+    web: https://dataint.net
+organization:
+  - name: DataInt
+    web: https://dataint.net
+issued_time: 2026
+sources:
+  - name: Sources and licences
+    access_url: https://logibook.dataint.net/en/sources
+references:
+  - title:
+    reference:


### PR DESCRIPTION
Two entries: `SocialSciences/Databook-Country-Indicators.yml` and
`Transportation/Logibook-Trade-Logistics-Reference.yml`.

Both sites are mine, so I'd rather raise the awkward parts myself than have you
find them.

### On "No advertisement"

The contributing policy says *"No advertisement! No Spam! No reputation
promotion!"* — and these sites do carry ads, so let me be precise about what
that means here.

Nothing is charged for. Every page and every figure is open to anyone: no
registration, no paywall, no subscription, no "sign up to see the rest". The
ads exist because the development costs have to come from somewhere, and I'd
rather run ads than put a donation banner on the page asking people for money.
There are no interstitials, no pop-ups, no gated content. If the policy means
"nothing that carries ads", then these don't qualify and that's a clear answer.
If it means "don't use this list to promote or spam", then I'd argue they do —
but it's your list and your call.

### On "downloaded directly from the linked site"

The policy lists four criteria and says *one or more* need to be met, so I'll
be straight about which one these fail. There is no API and no bulk download.
What they do is consolidate existing public sources into per-country reference
profiles and show the provenance next to every value.

Where I think they earn their place is the second criterion — *contributing
valuable knowledge for a specific domain* — because of the joins:

- **Databook** — 244 countries, 108 openly licensed datasets (World Bank WDI,
  WHO GHO, UNESCO UIS, UN DESA WPP, CIA World Factbook), 15 sections each,
  every figure with source and year. Started after the CIA stopped updating the
  World Factbook in February 2026.
- **Logibook** — 250 countries, 98 datasets. `Transportation` already has
  `OpenFlights.yml`, and I use OpenFlights, so I'm partly derivative there. The
  part that isn't: a port page carries its nearest airport, city and trade zone
  *with distances* — that needs UN/LOCODE joined against NGA WPI and World Bank
  SEZ data, and doesn't exist in any single source I know of.

### Checks run

- `python tests/validate.py` passes, exit code 0, both files parsed
- `category` matches the folder name for both
- `title`, `homepage`, `category` present as required
- Counts were read off the live pages today, not estimated

If the ad question settles it, close this — no hard feelings, and thanks for
keeping the list running.
