### PR TITLE
Add KI-Zugangsindex (robots.txt panel of 600 German .de domains) under ComputerNetworks

### DIFF
--- a/core/ComputerNetworks/KI-Zugangsindex.yml
+++ b/core/ComputerNetworks/KI-Zugangsindex.yml
@@ -1,0 +1,42 @@
+---
+title: 'KI-Zugangsindex: robots.txt longitudinal panel of 600 German (.de) domains'
+homepage: https://peppe1337.github.io/ki-zugangsindex/
+category: ComputerNetworks
+description: >-
+  A repeated robots.txt measurement of a fixed panel of 600 German .de domains
+  (300 highest-ranked and a systematic sample of 300 with Tranco rank above
+  50,000). Records for each domain whether each of 14 AI crawler user-agents is
+  disallowed from / under RFC 9309, including the wildcard fallback. First
+  measurement point 2026-08-25 -- 77 of 235 top domains (32.8%) and 31 of 210
+  small domains (14.8%) block at least one of GPTBot, OAI-SearchBot, ClaudeBot
+  or PerplexityBot. The panel is never re-drawn, so the series measures change
+  rather than sampling differences. All 600 raw robots.txt responses and the
+  parser are included.
+version: 1.0.0
+keywords: robots.txt, ai crawlers, gptbot, claudebot, perplexitybot, germany, .de domains, longitudinal, web measurement
+image:
+temporal: 2026
+spatial: Germany (.de top-level domain)
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: true
+data_dictionary:
+language: de
+license: CC BY 4.0 (data), MIT (code)
+publisher:
+- name: Christopher Kraft
+  web: https://peppe1337.github.io/ki-zugangsindex/
+organization:
+- name: Christopher Kraft
+  web: https://peppe1337.github.io/ki-zugangsindex/
+issued_time: 2026
+sources:
+- name: Repository with raw data and measurement code
+  access_url: https://github.com/peppe1337/ki-zugangsindex
+- name: Dataset page
+  access_url: https://peppe1337.github.io/ki-zugangsindex/
+references:
+- title:
+  reference:


### PR DESCRIPTION
Adds `core/ComputerNetworks/KI-Zugangsindex.yml`.

**What it is.** A robots.txt measurement of a **fixed panel of 600 German `.de` domains** —
the 300 highest-ranked in Tranco plus a systematic sample (every 88th) of 300 domains ranked
below 50,000. For each domain it records whether each of 14 AI crawler user-agents is
disallowed from `/` under RFC 9309, including the wildcard fallback. All 600 raw `robots.txt`
responses and the parser are in the repository, so every published figure can be recomputed.

**Disclosure: this is my own dataset.** I am submitting it because it fits the category, not
as a third-party recommendation.

**Relationship to the existing entry.** `core/ComputerNetworks/AI-Crawler-Blocking-Index.yml`
(Crawlora, merged 2026-07-13) covers the Tranco top 1M worldwide for a single day. This is a
different shape of data, not a bigger or better version of it:

| | Crawlora index | this entry |
|---|---|---|
| Scope | 998,497 domains, worldwide | 600 domains, `.de` only |
| Sampling | top 1M as of the run | **fixed panel, never re-drawn** |
| Time | one measurement day | repeated on the same domains |
| Low-traffic sites | included in the aggregate | **separate group by design** |

I used the Crawlora data as an independent check on my own, and the two agree closely: on the
392 panel domains evaluable in both, 32.3 % vs 31.9 % (top group) and 12.3 % vs 14.7 % (small
group), 66 days apart. That comparison, the attribution and its limitations are published at
<https://peppe1337.github.io/ki-zugangsindex/> — CC BY 4.0 is credited there and in the
dataset metadata.

**Honest limitations, stated up front:**

- **There is currently one measurement point** (2026-08-25). The panel is fixed so that a
  series *can* be built; the series itself is one point long today. The entry says
  "first measurement point", not "time series".
- `robots.txt` records what operators *declare*. It does not measure whether crawlers comply,
  and it cannot see network-level blocking.
- No DOI, no Zenodo/Kaggle/HuggingFace mirror.

`python3 tests/validate.py` passes (exit 0). I also verified the check actually fails when the
`category` field is made wrong, so the green result means something.

Happy to adjust wording, category, or to withdraw this if it is not a fit.
