### PR TITLE
Add two U.S. housing affordability datasets (rent-vs-own screen + DPA survey)

### DIFF
--- a/core/Economics/VanToVault-DPA-83-Metros.yml
+++ b/core/Economics/VanToVault-DPA-83-Metros.yml
@@ -1,0 +1,31 @@
+---
+title: Van to Vault DPA Survey - Down Payment Assistance in 83 U.S. Metros
+homepage: https://vantovault.com/library/down-payment-assistance-duplex/
+category: Economics
+description: A hand-checked 2026 survey of down payment assistance availability across 83 U.S. metro areas, answering a question program websites rarely state directly - whether an owner-occupant can use assistance to buy a two-to-four unit property and live in one unit. Each metro records the program name, advertised maximum assistance, a source URL, an as-of date, and a status field separating program_found (72 metros) from none_found (9) and unconfirmed (2), so a checked-but-empty metro is never confused with an unchecked one. Several state and local agencies confirmed or corrected entries in writing during compilation. Available as CSV and JSON, no signup.
+version: 1.0
+keywords: housing, down payment assistance, first time home buyer, housing policy, united states, metropolitan areas
+image:
+temporal: 2026
+spatial: United States
+access_level: public
+copyrights: CC BY 4.0
+accrual_periodicity: irregular
+specification:
+data_quality: true
+data_dictionary: https://vantovault.com/library/down-payment-assistance-duplex/
+language: en
+license: CC BY 4.0
+publisher:
+  - name: Van to Vault
+    web: https://vantovault.com/
+organization:
+  - name: Van to Vault
+    web: https://vantovault.com/
+issued_time: 2026.08
+sources:
+  - name: Van to Vault DPA Survey
+    access_url: https://vantovault.com/wp-content/uploads/2026/08/vantovault-dpa-83-metros.csv
+references:
+  - title: Down payment assistance for 2-4 unit owner-occupied purchase, 83 US metros (Zenodo)
+    reference: https://doi.org/10.5281/zenodo.22019630

--- a/core/Economics/VanToVault-Foothold-Metros.yml
+++ b/core/Economics/VanToVault-Foothold-Metros.yml
@@ -1,0 +1,31 @@
+---
+title: Van to Vault Foothold - Rent-vs-Own Screening Data for 83 U.S. Metros
+homepage: https://vantovault.com/library/foothold-score/
+category: Economics
+description: The dataset behind the Foothold screen, which tests where a first-time buyer with little cash can buy a two-to-four unit building, live in one unit and come out ahead of renting. 23,424 listings across 83 U.S. metro areas were screened against seven absolute tests covering price floor, FHA loan limit, condition by price per square foot, gross yield ceiling, neighborhood violent crime, residential abandonment and five-year home value trend. One row per metro with entry price, typical price, surviving listing count, monthly amount kept versus renting, keep ratio, rank and score. Available as CSV and JSON, no signup.
+version: 1.0
+keywords: housing, real estate, housing affordability, rent versus own, multifamily, metropolitan areas, united states
+image:
+temporal: 2026
+spatial: United States
+access_level: public
+copyrights: CC BY 4.0
+accrual_periodicity: irregular
+specification:
+data_quality: true
+data_dictionary: https://vantovault.com/library/foothold-score/
+language: en
+license: CC BY 4.0
+publisher:
+  - name: Van to Vault
+    web: https://vantovault.com/
+organization:
+  - name: Van to Vault
+    web: https://vantovault.com/
+issued_time: 2026.08
+sources:
+  - name: Van to Vault Foothold Index
+    access_url: https://vantovault.com/wp-content/uploads/2026/08/vantovault-foothold-metros.csv
+references:
+  - title: Foothold - rent-vs-own screen for 2-4 unit homes across 83 US metros (Zenodo)
+    reference: https://doi.org/10.5281/zenodo.22019647


### PR DESCRIPTION
Adds two original, openly licensed U.S. housing datasets under Economics.

**Foothold** - 83 metros screened for where a first-time buyer can buy a two-to-four unit building, live in one unit and come out ahead of renting. 23,424 listings tested against seven absolute checks. DOI 10.5281/zenodo.22019647

**DPA Survey** - a hand-checked survey of down payment assistance across the same 83 metros, recording whether assistance can be used on a two-to-four unit owner-occupied purchase. Several agencies confirmed entries in writing. DOI 10.5281/zenodo.22019630

Both are CC BY 4.0, downloadable as CSV and JSON with no signup, and archived on Zenodo with permanent DOIs. Methodology is published alongside each.