### PR TITLE
Add three CC BY reference datasets: TOEIC score curve, sexagenary cycle, film stocks

### DIFF
--- a/core/Education/TOEIC-Raw-to-Scaled-Approximation.yml
+++ b/core/Education/TOEIC-Raw-to-Scaled-Approximation.yml
@@ -1,0 +1,29 @@
+---
+title: TOEIC raw-to-scaled score approximation curve
+homepage: https://github.com/alice51849/lumi-open-data/tree/master/toeic-score-conversion
+category: Education
+description: A transparent raw-correct to scaled-score reference curve for TOEIC Listening & Reading, 101 rows per section covering 0-100 raw correct answers. ETS does not publish one universal conversion table - official scores are equated per test form - so this set is explicitly an approximation for practice-test estimation, built by linear interpolation through published preparation-chart anchor points in 5-point scaled increments, with the same curve used for both sections so neither is implicitly favoured. The method and its limits are stated inside the file. JSON, directly downloadable, no login.
+version: 2026-07-01
+keywords: TOEIC, language testing, score conversion, English proficiency, practice tests
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity: irregular
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license: CC BY 4.0
+publisher:
+  - name: Lumi Studio
+    web: https://github.com/alice51849/lumi-open-data
+organization:
+  - name: Lumi Studio
+    web: https://github.com/alice51849/lumi-open-data
+issued_time: 2026-07
+sources:
+  - name: toeic-raw-to-scaled.json
+    access_url: https://raw.githubusercontent.com/alice51849/lumi-open-data/master/toeic-score-conversion/toeic-raw-to-scaled.json
+references: []

--- a/core/ImageProcessing/Film-Stocks-Reference.yml
+++ b/core/ImageProcessing/Film-Stocks-Reference.yml
@@ -1,0 +1,29 @@
+---
+title: Photographic film stocks reference
+homepage: https://github.com/alice51849/lumi-open-data/tree/master/film-stocks
+category: ImageProcessing
+description: 25 well-known photographic film stocks with their characteristics in machine-readable form, for film-simulation work, photography education and image metadata tooling. The file notes that availability, datasheets and emulsion characteristics change over time and that manufacturer documentation is authoritative for technical decisions. JSON, directly downloadable, no login.
+version: 2026-07-01
+keywords: film photography, film stocks, film simulation, color grading, image metadata
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity: irregular
+specification:
+data_quality: false
+data_dictionary:
+language: en
+license: CC BY 4.0
+publisher:
+  - name: Lumi Studio
+    web: https://github.com/alice51849/lumi-open-data
+organization:
+  - name: Lumi Studio
+    web: https://github.com/alice51849/lumi-open-data
+issued_time: 2026-07
+sources:
+  - name: film-stocks.json
+    access_url: https://raw.githubusercontent.com/alice51849/lumi-open-data/master/film-stocks/film-stocks.json
+references: []

--- a/core/SocialSciences/Chinese-Zodiac-Sexagenary-Cycle.yml
+++ b/core/SocialSciences/Chinese-Zodiac-Sexagenary-Cycle.yml
@@ -1,0 +1,29 @@
+---
+title: Chinese zodiac sexagenary cycle, 1924-2044
+homepage: https://github.com/alice51849/lumi-open-data/tree/master/chinese-zodiac
+category: SocialSciences
+description: 121 consecutive years of the Chinese sexagenary (ganzhi) cycle, each row giving the heavenly stem, earthly branch, zodiac animal and five-element class for the year whose Lunar New Year falls in that Gregorian year. The derivation is published with the data - 1924 anchored as Jia-Zi Wood Rat, then modulo 10 and modulo 12 from there - so any row can be checked rather than trusted. The file states plainly that zodiac years follow the lunisolar calendar, so dates before Lunar New Year belong to the previous row; that boundary is where most implementations get this wrong. JSON, directly downloadable, no login.
+version: 2026-07-01
+keywords: Chinese calendar, sexagenary cycle, ganzhi, zodiac, lunisolar calendar, five elements
+image:
+temporal: 1924-2044
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity: irregular
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license: CC BY 4.0
+publisher:
+  - name: Lumi Studio
+    web: https://github.com/alice51849/lumi-open-data
+organization:
+  - name: Lumi Studio
+    web: https://github.com/alice51849/lumi-open-data
+issued_time: 2026-07
+sources:
+  - name: chinese-zodiac.json
+    access_url: https://raw.githubusercontent.com/alice51849/lumi-open-data/master/chinese-zodiac/chinese-zodiac.json
+references: []


### PR DESCRIPTION
Three entries from [lumi-open-data](https://github.com/alice51849/lumi-open-data), all CC BY 4.0, all plain JSON served from raw.githubusercontent.com with no login or purchase.

| Entry | Category | Contents |
|---|---|---|
| TOEIC raw-to-scaled score approximation curve | Education | 101 rows per section, 0-100 raw correct |
| Chinese zodiac sexagenary cycle, 1924-2044 | SocialSciences | 121 years: stem, branch, animal, element |
| Photographic film stocks reference | ImageProcessing | 25 stocks with characteristics |

Two things I want to be upfront about, since accuracy matters more here than coverage:

- **The TOEIC set is an approximation and says so in the file.** ETS does not publish a universal raw-to-scaled table; official scores are equated per test form. The curve is linear interpolation through published preparation-chart anchor points, and the same curve is used for Listening and Reading rather than inventing a difference between them. It is useful for practice-test estimation and nothing more. I have set `data_quality: false` on it accordingly.
- **I did not submit our passport-photo dataset.** The repository already has two entries covering that ground, one of them considerably larger and with a citable DOI. A third smaller one would add nothing.

The sexagenary-cycle set is complementary to the existing `NaturalLanguage/bazi-nayin` entry rather than overlapping: that one maps the 30 nayin terms, this one is the year-by-year calendar table. Its derivation is published alongside the data so any row can be checked, and it documents the Lunar New Year boundary that most implementations get wrong.

Homepages point at the dataset directories, not at anything commercial.