### PR TITLE
Add Pokemon Card Sold-Price Reference by Grade

### DIFF
--- a/core/Entertainment/Pokemon-Card-Sold-Price-Reference.yml
+++ b/core/Entertainment/Pokemon-Card-Sold-Price-Reference.yml
@@ -1,0 +1,24 @@
+---
+title: Pokemon Card Sold-Price Reference by Grade
+homepage: https://gemsnipe.com/cards/
+category: Entertainment
+description: Median sold-price reference for 486 Pokemon cards across raw (ungraded), PSA 9, and PSA 10 eBay sales, compiled from real graded and ungraded sold comps. Each row carries the median price and sample count for raw/PSA9/PSA10, a confidence flag by sample size, and the PSA10-over-PSA9 grading premium multiple (median 4.9x across cards with both grades). Reference pricing only, sorted by trading volume, not a ranked opportunity list. Direct CSV download, no login; DOI-minted and mirrored on Zenodo, Kaggle, Hugging Face, GitHub and OSF.
+version: 1.0
+keywords: pokemon, trading cards, PSA grading, PSA 10, sold prices, collectibles, ebay
+image:
+temporal: 2026-08-27
+spatial: N/A (eBay listings, United States marketplace)
+access_level: public
+copyrights: CC-BY-4.0
+accrual_periodicity: irregular
+specification:
+data_quality: true
+data_dictionary: https://gemsnipe.com/cards/
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: GemSnipe
+    web: https://gemsnipe.com/
+references:
+  - title: Zenodo record (DOI)
+    reference: https://doi.org/10.5281/zenodo.22124729

--- a/core/Entertainment/Pokemon-Card-Sold-Price-Reference.yml
+++ b/core/Entertainment/Pokemon-Card-Sold-Price-Reference.yml
@@ -1,6 +1,6 @@
 ---
 title: Pokemon Card Sold-Price Reference by Grade
-homepage: https://gemsnipe.com/cards/
+homepage: https://zenodo.org/records/22124729
 category: Entertainment
 description: Median sold-price reference for 486 Pokemon cards across raw (ungraded), PSA 9, and PSA 10 eBay sales, compiled from real graded and ungraded sold comps. Each row carries the median price and sample count for raw/PSA9/PSA10, a confidence flag by sample size, and the PSA10-over-PSA9 grading premium multiple (median 4.9x across cards with both grades). Reference pricing only, sorted by trading volume, not a ranked opportunity list. Direct CSV download, no login; DOI-minted and mirrored on Zenodo, Kaggle, Hugging Face, GitHub and OSF.
 version: 1.0


### PR DESCRIPTION
Median sold-price reference for 486 Pokemon cards across raw, PSA 9, and PSA 10 eBay sales — compiled from real graded/ungraded sold comps, with sample counts and a confidence flag per row.

- Direct CSV, no login required
- Mirrored on Zenodo (DOI), Kaggle, Hugging Face, GitHub and OSF
- `tests/validate.py` passes clean locally

Compiled by GemSnipe (gemsnipe.com), a Pokemon card centering/grading tool. A second, unrelated dataset from the same publisher (centering measurements) is already open as #550.