### PR TITLE
Add Mental Health Startup Graveyard dataset (Healthcare)

### DIFF
--- a/core/Healthcare/Mental-Health-Startup-Graveyard.yml
+++ b/core/Healthcare/Mental-Health-Startup-Graveyard.yml
@@ -1,0 +1,39 @@
+---
+title: Mental Health Startup Graveyard
+homepage: https://zenodo.org/records/22125661
+category: Healthcare
+description: 542 digital mental health organizations that left the market between 2000 and 2026, each coded on up to 26 fields including business model, who the paying customer was, funding raised, reason for market exit, published clinical evidence, presence of a medical co-founder, country and years of operation. Compiled from Crunchbase, CB Insights, Tracxn, public deadpool databases, app store removals, domain data and trade press, with every company confirmed against at least two independent sources. A separate file documents the reasoning behind each coding decision, so the judgement calls can be audited. Known limits are stated in the README, among them that funding is disclosed for 322 of the 542 companies and that the sample is a graveyard rather than a random cross-section of the market.
+version: '1.0'
+keywords: mental health, digital health, telehealth, digital therapeutics, startups, business models, company shutdowns, market exit, health technology
+image:
+temporal: 2000/2026
+spatial: Worldwide
+access_level: public
+copyrights:
+accrual_periodicity: irregular
+specification:
+data_quality: false
+data_dictionary: https://mentalium.me/data/README.md
+language: en
+license: CC BY 4.0
+publisher:
+  - name: Mentalium
+    web: https://mentalium.me/
+organization:
+  - name: Mentalium
+    web: https://mentalium.me/
+issued_time: 2026-08-27
+sources:
+  - name: Zenodo record
+    access_url: https://doi.org/10.5281/zenodo.22125660
+  - name: CSV download
+    access_url: https://mentalium.me/data/mh-graveyard-companies.csv
+  - name: JSON download
+    access_url: https://mentalium.me/data/mh-graveyard-companies.json
+  - name: Coding rationale, CSV
+    access_url: https://mentalium.me/data/mh-graveyard-labels-rationale.csv
+references:
+  - title: Dataset landing page with column reference and method
+    reference: https://mentalium.me/en/research/mental-health-startup-graveyard-dataset/
+  - title: Mirror deposit on Figshare
+    reference: https://doi.org/10.6084/m9.figshare.33350502


### PR DESCRIPTION
Adds one entry under `core/Healthcare/`.

**What it is.** 542 digital mental health organizations that left the market between 2000 and 2026, one row each, coded on up to 26 fields: business model, who the paying customer was, funding raised, reason for market exit, published clinical evidence, whether a clinician co-founded the company, country, years of operation.

**Provenance.** Compiled from Crunchbase, CB Insights, Tracxn, public deadpool databases, app store removals, domain data and trade press. Every company confirmed against at least two independent sources; rebrands and country editions merged. A separate file carries the reasoning behind each coding decision, so the judgement calls can be checked rather than taken on trust.

**Against the quality criteria in CONTRIBUTING:**

- *Uncommon to obtain legally* — no comparable open catalogue of shutdowns in this niche exists; the large deadpool databases cover every industry at once.
- *Valuable domain knowledge* — the payer field alone separates 53% mortality from 21% within the same market and years.
- *Downloadable directly* — CSV and JSON, no login, no paywall, CC BY 4.0.
- *No promotion* — the homepage field points at the Zenodo deposit rather than a company site.

**Limits are documented** in the dataset README and repeated in the entry description: funding is disclosed for 322 of 542 companies, closure dates for products that died quietly are approximate, about 67% of the sample is US and UK, and the set is a graveyard rather than a random cross-section, so shares compare groups to each other and are not a probability of failure.

**Disclosure.** I work at the company that compiled and published the data. It was collected for our own strategy and released as it was; our own product is not in the sample, which only covers organizations that have already shut down.

DOI: 10.5281/zenodo.22125660