### PR TITLE
Add Journal Submission Requirements dataset (Education)

### DIFF
--- a/core/Education/Journal-Submission-Requirements.yml
+++ b/core/Education/Journal-Submission-Requirements.yml
@@ -1,0 +1,24 @@
+---
+title: Journal Submission Requirements - Author guidelines of 7,239 academic journals
+homepage: https://github.com/scraiber/journal-submission-requirements
+category: Education
+description: Normalized submission requirements for 7,239 academic journals, collected from each journal's own author guidelines. Covers word limits, abstract word limits, reference caps, page/figure/keyword limits per manuscript type, with source URLs, plus journal metadata (ISSNs, publisher, h-index) and OpenAlex field/domain mapping for every journal. Two CSVs plus aggregate statistics; analysis at https://scraiber.com/journal-statistics.
+version: 2026.08
+keywords: academic publishing, journals, author guidelines, submission requirements, word limits, scholarly communication
+image:
+temporal:
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: true
+data_dictionary: https://github.com/scraiber/journal-submission-requirements#whats-inside
+language: English
+license: CC-BY-4.0
+publisher:
+  - name: Scraiber
+    web: https://scraiber.com
+organization:
+issued_time: 2026-08-27
+sources: []


### PR DESCRIPTION
Adds the Journal Submission Requirements dataset: normalized author-guideline rules (word limits, abstract word limits, reference caps, page/figure/keyword limits per manuscript type, each with its source URL) for 7,239 academic journals, plus journal metadata and an OpenAlex field/domain mapping.

- Direct download, no login: https://github.com/scraiber/journal-submission-requirements (two CSVs + aggregate stats JSON)
- License: CC BY 4.0
- Aggregate analysis: https://scraiber.com/journal-statistics

To our knowledge no comparable open dataset of normalized submission requirements across journals exists.