### PR TITLE
Add two open datasets on iPhone step counter apps (Software)

### DIFF
--- a/core/Software/iPhone-Step-Counter-App-Store-Survey.yml
+++ b/core/Software/iPhone-Step-Counter-App-Store-Survey.yml
@@ -1,0 +1,37 @@
+---
+title: iPhone Step Counter App Store Survey
+homepage: https://angelstep.app/data
+category: Software
+description: A hand-read survey of 18 iPhone step counter apps on the US App Store, measured on 17 August 2026. It records the one figure Apple's search interface does not expose - what an app charges after install - by opening each app's own listing and reading its In-App Purchases block, together with ratings, rating counts, last-updated month, and whether the listing's own text mentions a widget, a lock screen widget or Apple Health. No ranking and no score - the file states what the store showed on that date. Published as JSON and CSV under CC BY 4.0, with a DOI.
+version: 1.0
+keywords: app store, ios, mobile apps, pedometer, in-app purchases, app pricing, widgets
+image:
+temporal: 2026-08-17
+spatial: United States App Store
+access_level: public
+copyrights: Compilation and method CC BY 4.0; the underlying facts are Apple's public store listings
+accrual_periodicity: never
+specification: https://angelstep.app/data/step-counter-survey.json
+data_quality: true
+data_dictionary: https://angelstep.app/data
+language: en
+license: CC BY 4.0
+publisher:
+  - name: Angel Step
+    web: https://angelstep.app
+organization:
+  - name: Angel Step
+    web: https://angelstep.app
+issued_time: 2026.08
+sources:
+  - name: Canonical JSON
+    access_url: https://angelstep.app/data/step-counter-survey.json
+  - name: Canonical CSV
+    access_url: https://angelstep.app/data/step-counter-survey.csv
+  - name: GitHub mirror
+    access_url: https://github.com/33nyc/step-counter-survey
+  - name: Hugging Face mirror
+    access_url: https://huggingface.co/datasets/thee3/step-counter-survey
+references:
+  - title: DOI
+    reference: https://doi.org/10.5281/zenodo.22032007

--- a/core/Software/iPhone-Step-Counter-Review-Themes.yml
+++ b/core/Software/iPhone-Step-Counter-Review-Themes.yml
@@ -1,0 +1,37 @@
+---
+title: What iPhone Step Counter Reviews Talk About
+homepage: https://angelstep.app/data/review-themes
+category: Software
+description: Counts of what 7,859 unique US App Store reviews of ten iPhone step counter apps talk about, matched against 21 themes by a hand-written dictionary of phrasings and split by rating band (1-2, 3-4 and 5 stars). It contains no review text, no author names and no per-review records - only counts, with the denominator on every row, so any share can be recomputed from the file. Joins to the store-listing survey of the same category on app_store_id. Published as JSON and CSV under CC BY 4.0.
+version: 1.0
+keywords: app reviews, app store, ios, mobile apps, pedometer, user feedback, text classification
+image:
+temporal: 2026-08-19
+spatial: United States App Store
+access_level: public
+copyrights: Compilation, structure, theme dictionary and method CC BY 4.0; no review text is republished
+accrual_periodicity: never
+specification: https://angelstep.app/data/step-counter-reviews.json
+data_quality: true
+data_dictionary: https://angelstep.app/data/review-themes
+language: en
+license: CC BY 4.0
+publisher:
+  - name: Angel Step
+    web: https://angelstep.app
+organization:
+  - name: Angel Step
+    web: https://angelstep.app
+issued_time: 2026.08
+sources:
+  - name: Canonical JSON
+    access_url: https://angelstep.app/data/step-counter-reviews.json
+  - name: Canonical CSV
+    access_url: https://angelstep.app/data/step-counter-reviews.csv
+  - name: GitHub mirror
+    access_url: https://github.com/33nyc/step-counter-review-themes
+  - name: Hugging Face mirror
+    access_url: https://huggingface.co/datasets/thee3/step-counter-review-themes
+references:
+  - title: Starter notebook on Kaggle
+    reference: https://www.kaggle.com/code/light33/step-counter-reviews-a-first-look


### PR DESCRIPTION
Two datasets about the same App Store category, each downloadable directly with no login, both CC BY 4.0.

**iPhone Step Counter App Store Survey** — 18 apps read off their own store pages on 17 Aug 2026. It records the figure Apple's search interface does not expose: what an app charges after install, taken from each listing's In-App Purchases block, alongside ratings, last-updated month and what the listing text claims about widgets and Apple Health. Has a DOI (10.5281/zenodo.22032007).

**What iPhone Step Counter Reviews Talk About** — 7,859 unique reviews of ten apps counted against 21 themes and split by rating band. It holds counts only: no review text, no author names, no per-review records. Every row carries its own denominator, so any share can be recomputed from the file.

Both join on `app_store_id`, so the pair supports the question neither answers alone: what the store claims versus what its customers write about.

Notes against the contribution policy:
- Uncommon to obtain legally in the open: in-app purchase prices are not exposed by Apple's search API, and no public dataset of review themes for this category existed.
- Downloadable directly (JSON and CSV over HTTPS, plus GitHub and Hugging Face mirrors), no login, no paywall.
- No ranking, no score and no recommendation appears in either file — deliberately, since the compiler is a participant in this market.
- Method, sampling caveats and the 500-per-sort cap Apple imposes travel inside the files themselves.