### PR TITLE
Add Turkish Olive Production Data (Agriculture)

### DIFF
--- a/core/Agriculture/Turkish-Olive-Production.yml
+++ b/core/Agriculture/Turkish-Olive-Production.yml
@@ -1,0 +1,39 @@
+---
+title: Turkish Olive Production Data
+homepage: https://github.com/yudumnet/zeytinnet
+category: Agriculture
+description: Olive and olive oil production in Turkiye at province, region and variety level. 45 provinces with 2024-25 season figures (table/oil split, tree counts, yield per tree, coordinates), an eleven-season series for the six largest producing provinces, area and output shares for five regions, and a mapping of 38 olive varieties to their growing regions. CSV, with a bilingual data dictionary and full source citations.
+version: 1.0
+keywords: olive, olive oil, Turkiye, Turkey, agriculture, crop production, horticulture, province, region, variety, zeytin, zeytinyagi, dataset, CSV
+image: https://zeytin.net/varlik/gorsel/turkiye-zeytin-haritasi.svg
+temporal: 2014-2025
+spatial: Turkiye
+access_level: public
+copyrights: CC BY 4.0
+accrual_periodicity: annual
+specification:
+data_quality: true
+data_dictionary: https://github.com/yudumnet/zeytinnet/blob/main/KAYNAKLAR.md
+language: tr, en
+license: CC BY 4.0
+publisher:
+  - name: zeytin.net
+    web: https://zeytin.net/
+organization:
+  - name: zeytin.net
+    web: https://zeytin.net/
+issued_time: 2026.08
+sources:
+  - name: Province production, 2024-25 season (CSV)
+    access_url: https://raw.githubusercontent.com/yudumnet/zeytinnet/main/veri/il-uretim-2024-25.csv
+  - name: Eleven-season series for six provinces (CSV)
+    access_url: https://raw.githubusercontent.com/yudumnet/zeytinnet/main/veri/il-seri-11-sezon.csv
+  - name: Regional area and output shares (CSV)
+    access_url: https://raw.githubusercontent.com/yudumnet/zeytinnet/main/veri/bolge.csv
+  - name: Variety to region mapping (CSV)
+    access_url: https://raw.githubusercontent.com/yudumnet/zeytinnet/main/veri/cesit-bolge.csv
+references:
+  - title: Data dictionary and source citations
+    reference: https://github.com/yudumnet/zeytinnet/blob/main/KAYNAKLAR.md
+  - title: Interactive olive map of Turkiye
+    reference: https://zeytin.net/zeytin-haritasi


### PR DESCRIPTION
Adds a dataset entry under **Agriculture**.

**Turkish Olive Production Data** — https://github.com/yudumnet/zeytinnet

Turkiye is the world's largest producer of table olives, but its production data
has not been available as a single machine-readable set at province level. This
dataset collects it:

- **45 provinces**, 2024-25 season: olives produced, the table/oil split, olive
  oil output, bearing and non-bearing tree counts, yield per tree, coordinates
- **Eleven-season series** for the six largest producing provinces, so alternate
  bearing (the olive's biennial yield swing) is visible rather than hidden
- **Five regions**: area and output shares
- **38 varieties** mapped to their growing regions

CSV, direct download, no login. `KAYNAKLAR.md` carries a bilingual data
dictionary and full source citations (national crop estimate for the figures,
a 2016 academic source for the variety mapping), plus explicit warnings about
the three ways this data is easy to misread — an empty cell means "no published
figure" rather than zero, table and oil tonnages are two destinations of one
crop rather than separate production, and a single season says nothing about a
trend.

Licensed CC BY 4.0.
