### PR TITLE
Add SBA 7(a) Charge-Off Rates under Finance

### DIFF
--- a/core/Finance/SBA-7a-Charge-Off-Rates.yml
+++ b/core/Finance/SBA-7a-Charge-Off-Rates.yml
@@ -1,6 +1,6 @@
 ---
 title: SBA 7(a) Loan Charge-Off Rates 1992-2026
-homepage: https://financeclearly.com/sba-7a-loan-data/
+homepage: https://github.com/Chadhauser/sba-7a-chargeoff-rates
 category: Finance
 description: Charge-off rates computed from the complete public record of US Small Business Administration 7(a) lending, fiscal years 1992 to 2026. Covers 1,912,539 loans, of which 1,363,711 have reached a conclusion by being either paid in full or charged off. Aggregated by state, NAICS industry and franchise brand. Franchise brand names are normalised before aggregation, correcting for the same brand appearing under multiple spellings in the source file.
 version: 1.0.0
@@ -15,3 +15,7 @@ data_quality: true
 data_dictionary: https://github.com/Chadhauser/sba-7a-chargeoff-rates
 language: en
 license: CC BY 4.0
+publisher:
+  - name: Finance Clearly
+    web: https://financeclearly.com
+citation: Edwards, P. (2026). SBA 7(a) Loan Charge-Off Rates 1992-2026. Finance Clearly. https://doi.org/10.5281/zenodo.22132218

--- a/core/Finance/SBA-7a-Charge-Off-Rates.yml
+++ b/core/Finance/SBA-7a-Charge-Off-Rates.yml
@@ -1,0 +1,17 @@
+---
+title: SBA 7(a) Loan Charge-Off Rates 1992-2026
+homepage: https://financeclearly.com/sba-7a-loan-data/
+category: Finance
+description: Charge-off rates computed from the complete public record of US Small Business Administration 7(a) lending, fiscal years 1992 to 2026. Covers 1,912,539 loans, of which 1,363,711 have reached a conclusion by being either paid in full or charged off. Aggregated by state, NAICS industry and franchise brand. Franchise brand names are normalised before aggregation, correcting for the same brand appearing under multiple spellings in the source file.
+version: 1.0.0
+keywords: SBA, 7(a) loans, small business lending, charge-off rates, default rates, franchise, NAICS, United States
+temporal: 1992-2026
+spatial: United States, all 50 states plus DC and Puerto Rico
+access_level: public
+copyrights: CC BY 4.0
+accrual_periodicity: annual
+specification: https://doi.org/10.5281/zenodo.22132218
+data_quality: true
+data_dictionary: https://github.com/Chadhauser/sba-7a-chargeoff-rates
+language: en
+license: CC BY 4.0


### PR DESCRIPTION
Adds `core/Finance/SBA-7a-Charge-Off-Rates.yml`.

**What it is**

Charge-off rates computed from the complete public record of US Small Business Administration 7(a) lending, fiscal years 1992 to 2026. The source file covers 1,912,539 loans, of which 1,363,711 have reached a conclusion by being either paid in full or charged off. Aggregated by state, NAICS industry and franchise brand.

**Against the quality criteria**

- Direct download, no login or purchase: aggregate CSVs at https://github.com/Chadhauser/sba-7a-chargeoff-rates
- Archived with a DOI: https://doi.org/10.5281/zenodo.22132218
- Licensed CC BY 4.0, free for any use including commercial
- The underlying SBA file is public under the US Freedom of Information Act

**Why the aggregation is not trivial**

Franchise brand names in the SBA source file are not consistently formatted, so the same brand appears under several spellings. Names are normalised before aggregation. Grouping on the raw field splits brands and produces incorrect figures, which is the main reason published analyses of this data disagree with each other.

Compiled by a chartered management accountant. Happy to adjust the entry if any field is wrong.