### PR TITLE
Add UK Payment Practices under Finance

### DIFF
--- a/core/Finance/UK-Payment-Practices.yml
+++ b/core/Finance/UK-Payment-Practices.yml
@@ -1,0 +1,21 @@
+---
+title: UK Payment Practices 2017-2026
+homepage: https://github.com/Chadhauser/uk-payment-practices
+category: Finance
+description: Aggregate figures from 114,758 statutory payment practices reports filed by large UK companies between 2017 and 2026. Every large UK company must report twice yearly how long it takes to pay suppliers and what proportion it pays late. Covers median days to pay, share of invoices paid within 30 days, share not paid within agreed terms, and the gap between each company's stated payment terms and its actual performance.
+version: 1.0.0
+keywords: payment practices, late payment, supplier payment, UK companies, days to pay, payment terms, small business, procurement
+temporal: 2017-2026
+spatial: United Kingdom
+access_level: public
+copyrights: CC BY 4.0
+accrual_periodicity: biannual
+specification: https://doi.org/10.5281/zenodo.22158494
+data_quality: true
+data_dictionary: https://github.com/Chadhauser/uk-payment-practices
+language: en
+license: CC BY 4.0
+publisher:
+  - name: Finance Clearly
+    web: https://financeclearly.com
+citation: Edwards, P. (2026). UK Payment Practices 2017-2026. Finance Clearly. https://doi.org/10.5281/zenodo.22158494


### PR DESCRIPTION
Adds `core/Finance/UK-Payment-Practices.yml`.

**What it is**

Aggregate figures from 114,758 statutory payment practices reports filed by large UK companies between 2017 and 2026. Every large UK company must report twice yearly how long it takes to pay suppliers and what proportion it pays late.

**Against the quality criteria**

- Direct download: CSVs at https://github.com/Chadhauser/uk-payment-practices
- Archived with a DOI: https://doi.org/10.5281/zenodo.22158494
- CC BY 4.0; underlying reports are Open Government Licence v3.0
- Statutory data under the Reporting on Payment Practices and Performance Regulations 2017

**Why the aggregation is worth having**

The government publishes a search tool for looking up one company at a time. There is no public aggregate. Two findings come out of it: payment has improved on every measure since reporting began, which runs against the common claim that late payment is worsening; and 65.5% of companies still pay slower than the terms they publish themselves.

Same contributor as #611, merged yesterday. Happy to adjust any field.