### PR TITLE
Add five measured open hardware/LLM datasets (CC BY 4.0, DOI-backed)

### DIFF
--- a/core/Economics/ddr5-ram-price-observations-2026.yml
+++ b/core/Economics/ddr5-ram-price-observations-2026.yml
@@ -1,0 +1,23 @@
+---
+title: DDR5 RAM Price Observations 2026
+homepage: https://huggingface.co/datasets/iBlessi/ddr5-ram-price-observations-2026
+category: Economics
+description: Dated cost-per-gigabyte observations for 32GB (2x16GB) DDR5 kits at named direct US retailers during the 2026 memory supply crisis, with explicit acceptance rules
+version: '1.0.0'
+keywords: DDR5, RAM, memory prices, price index, cost per gigabyte, retail pricing, time series
+image:
+temporal: 2026
+spatial: United States
+access_level: public
+copyrights:
+accrual_periodicity: daily
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license: CC BY 4.0
+publisher: TechFuelHQ
+organization: TechFuelHQ
+issued_time: '2026-08-01'
+sources:
+  - https://doi.org/10.5281/zenodo.22169554

--- a/core/Economics/hdd-price-index-8tb.yml
+++ b/core/Economics/hdd-price-index-8tb.yml
@@ -1,0 +1,23 @@
+---
+title: HDD Price Index - Dated Cost per Terabyte for 8TB Drives (2026)
+homepage: https://huggingface.co/datasets/iBlessi/hdd-price-index-8tb
+category: Economics
+description: Dated cost-per-terabyte observations for 8TB NAS and desktop hard drives at named direct US retailers during the 2026 supply crunch, with a logged rejection trail
+version: '1.0.0'
+keywords: hard disk drive, price index, storage, cost per terabyte, retail pricing, NAS, time series
+image:
+temporal: 2026-08
+spatial: United States
+access_level: public
+copyrights:
+accrual_periodicity: daily
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license: CC BY 4.0
+publisher: TechFuelHQ
+organization: TechFuelHQ
+issued_time: '2026-08-12'
+sources:
+  - https://doi.org/10.5281/zenodo.22169517

--- a/core/MachineLearning/local-llm-runtime-comparison-rtx-5080.yml
+++ b/core/MachineLearning/local-llm-runtime-comparison-rtx-5080.yml
@@ -1,0 +1,23 @@
+---
+title: Ollama vs llama.cpp vs LM Studio on One RTX 5080
+homepage: https://huggingface.co/datasets/iBlessi/local-llm-runtime-comparison-rtx-5080
+category: MachineLearning
+description: Controlled inference-runtime comparison on identical hard-linked sha256-verified GGUF bytes; decode, prefill, VRAM, RAM working set, TTFT and load time
+version: '1.1.0'
+keywords: LLM, inference, benchmark, Ollama, llama.cpp, LM Studio, GGUF, local LLM, RTX 5080
+image:
+temporal: 2026-08
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license: CC BY 4.0
+publisher: TechFuelHQ
+organization: TechFuelHQ
+issued_time: '2026-08-20'
+sources:
+  - https://doi.org/10.5281/zenodo.22169533

--- a/core/MachineLearning/rtx-5080-llm-power-efficiency.yml
+++ b/core/MachineLearning/rtx-5080-llm-power-efficiency.yml
@@ -1,0 +1,23 @@
+---
+title: RTX 5080 LLM Power Efficiency (Watts and Joules per Token)
+homepage: https://huggingface.co/datasets/iBlessi/rtx-5080-llm-power-efficiency
+category: MachineLearning
+description: Measured board power, tokens per joule, and electricity cost per million tokens for local LLM inference on a retail RTX 5080, with raw 1Hz nvidia-smi telemetry
+version: '1.0.0'
+keywords: LLM, inference, GPU power, energy efficiency, tokens per joule, RTX 5080, idle power, local LLM
+image:
+temporal: 2026-08
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license: CC BY 4.0
+publisher: TechFuelHQ
+organization: TechFuelHQ
+issued_time: '2026-08-19'
+sources:
+  - https://doi.org/10.5281/zenodo.22169575

--- a/core/Software/mcp-server-resource-benchmark.yml
+++ b/core/Software/mcp-server-resource-benchmark.yml
@@ -1,0 +1,23 @@
+---
+title: MCP Server Resource Benchmark (RAM, Startup Time, Tool Counts)
+homepage: https://huggingface.co/datasets/iBlessi/mcp-server-resource-benchmark
+category: Software
+description: Measured resident memory, startup time and tool counts for 11 Model Context Protocol servers, plus a concurrent five-server stack, using descendant-process-tree RSS
+version: '1.0.0'
+keywords: Model Context Protocol, MCP, benchmark, memory footprint, resident set size, LLM tooling
+image:
+temporal: 2026-08
+spatial:
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license: CC BY 4.0
+publisher: TechFuelHQ
+organization: TechFuelHQ
+issued_time: '2026-08-20'
+sources:
+  - https://doi.org/10.5281/zenodo.22169541


### PR DESCRIPTION
Adds five first-party measured datasets. All are CC BY 4.0, downloadable without login, and each carries a permanent Zenodo DOI.

| Entry | Category | DOI |
|---|---|---|
| RTX 5080 LLM Power Efficiency | MachineLearning | 10.5281/zenodo.22169575 |
| Ollama vs llama.cpp vs LM Studio | MachineLearning | 10.5281/zenodo.22169533 |
| MCP Server Resource Benchmark | Software | 10.5281/zenodo.22169541 |
| HDD Price Index (8TB, $/TB) | Economics | 10.5281/zenodo.22169517 |
| DDR5 RAM Price Observations 2026 | Economics | 10.5281/zenodo.22169554 |

**On CONTRIBUTING guidance:** every `homepage` points at the Hugging Face dataset repository rather than at the website that uses the data, per the rule about pointing directly at the repository. No links to the originating site are included in these entries.

**Why these meet the high-quality bar:**

- *Uncommon to obtain legally in the open community* — these are original measurements on physical hardware, not scrapes or re-publications. I am not aware of published tokens-per-joule figures for consumer GPUs, or of a runtime comparison that holds the model file constant.
- *Contributing valuable knowledge for a specific domain* — the runtime comparison shares one set of GGUF files between applications via hard links, verified by sha256, so the measured delta is attributable to the runtime rather than to an uncontrolled quantization difference. Most published comparisons do not control for this.
- *Directly downloadable* — CSV/JSON on Hugging Face and Zenodo, no login, no paywall.

**Method transparency:** each dataset card documents the failures alongside the results, including a background process that was found depressing decode ~15% mid-capture (suspended and re-measured), a prompt-cache artefact that inflates "prefill" to ~60k tok/s unless a per-iteration nonce is used, and a retail listing-identity instability that can manufacture price movements that never occurred. The price series also carries an activation gate that is currently closed, so it publishes observations only rather than an index row.

Happy to split this into separate PRs, move any entry to a different category, or drop any entry that is not a fit.

Disclosure: I am the author of these datasets. They are published under CC BY 4.0 with no paywall, advertising, or registration on the linked repositories.
