### PR TITLE
Add PayCrunch-Best-Paying-States under economics

### DIFF
--- a/core/Economics/PayCrunch-Best-Paying-States.yml
+++ b/core/Economics/PayCrunch-Best-Paying-States.yml
@@ -1,0 +1,17 @@
+---
+title: PayCrunch Best-Paying States by Occupation
+homepage: https://paycrunch.co/best-paying-states.html
+category: Economics
+description: Annual wages for 824 detailed US occupations, with the state that pays each one most. Covers the national 10th percentile, median and 90th percentile, and applies a 500-employee reporting floor so a state figure built on a handful of survey responses cannot become the answer; the unfiltered result is kept in a second column for comparison. Derived from the U.S. Bureau of Labor Statistics Occupational Employment and Wage Statistics, May 2025 release. Direct CSV and JSON download, no login. A companion endpoint gives median and 90th percentile by state for 352 occupations across 11,548 area rows.
+keywords: wages, salaries, occupations, employment, labor, BLS, OEWS, United States, states
+license: CC BY 4.0
+access_level: public
+language: en
+issued_time: 2026
+specification: https://paycrunch.co/openapi.json
+sources:
+  - name: U.S. Bureau of Labor Statistics, Occupational Employment and Wage Statistics, May 2025
+    web: https://www.bls.gov/oes/
+organization:
+  - name: PayCrunch
+    web: https://paycrunch.co/


### PR DESCRIPTION
Adds `core/Economics/PayCrunch-Best-Paying-States.yml`.

**What it is.** Annual wages for 824 detailed US occupations with the state that pays each one most, alongside the national 10th percentile, median and 90th percentile. Derived from the U.S. Bureau of Labor Statistics Occupational Employment and Wage Statistics, May 2025 release.

**Why it is not just a copy of the BLS release.** BLS publishes national and state wages as separate spreadsheets and leaves the join to you. Two things are added here. First, a 500-employee reporting floor, because unfiltered state figures produce artefacts — BLS's own numbers give $113,810 for door-to-door newspaper sales in Missouri, drawn from a handful of responses. Second, the unfiltered answer is kept in a second column, so you can see exactly which occupations the floor changes the answer for, which is arguably the more interesting column of the two.

**Downloads, no login, no barrier.** CSV: https://paycrunch.co/data/open/best-paying-states.csv · JSON: https://paycrunch.co/data/open/best-paying-states.json · a companion endpoint gives median and 90th percentile by state for 352 occupations across 11,548 area rows: https://paycrunch.co/api/v1/state-wages.json

**Licence.** CC BY 4.0. There is an OpenAPI 3.1 spec at https://paycrunch.co/openapi.json.

On the "no advertisement, no reputation promotion" rule: the linked page leads with the download links and the methodology, and the underlying source is credited as BLS on every row. Happy to point `homepage` straight at the CSV instead if you would prefer the entry avoid the HTML page altogether.

Validated locally: the file parses, carries the three required fields, and `category` matches the folder name.