### PR TITLE
Add US Federal Campgrounds dataset (Campsite Atlas Open Data)

### DIFF
--- a/core/Government/US-Federal-Campgrounds-Campsite-Atlas.yml
+++ b/core/Government/US-Federal-Campgrounds-Campsite-Atlas.yml
@@ -1,0 +1,11 @@
+---
+title: US Federal Campgrounds (Campsite Atlas Open Data)
+homepage: https://campsiteatlas.com/data/
+category: Government
+description: All 5,780 campgrounds in the U.S. federal recreation system (Forest Service, Army Corps, National Park Service, BLM, Bureau of Reclamation, Fish & Wildlife) as one CSV, cleaned from the Recreation.gov RIDB export and refreshed nightly. Fields include reservable vs first-come, site counts, electric/water/sewer hookups, pets, campfires, max RV length, confirmed-free flag, and booking links.
+version:
+keywords: campgrounds,camping,recreation.gov,ridb,federal-lands,rv,national-forests,government
+temporal: 2025-2026
+spatial: United States
+access_level: open
+copyrights: CC0


### PR DESCRIPTION
Adds a Government entry for every campground in the U.S. federal recreation system (5,780; Forest Service, Army Corps, NPS, BLM, Reclamation, Fish & Wildlife), cleaned from the Recreation.gov RIDB full export.

- Single CSV, CC0: reservable vs first-come, site counts, electric/water/sewer, pets, campfires, max RV length, confirmed-free flag, booking + official NPS links
- Refreshed nightly: https://campsiteatlas.com/data/ (with column dictionary and Dataset schema.org markup)
- Version-history mirror: https://github.com/kirkwood-justin/campsite-atlas-data

Companion to the Park Atlas entry (#616), same maintainer. Thanks for the fast merge on that one.