### PR TITLE
Add US ZIP Code Sample Data under GIS

### DIFF
--- a/core/GIS/US-ZIP-Code-Sample-Data.yml
+++ b/core/GIS/US-ZIP-Code-Sample-Data.yml
@@ -1,0 +1,34 @@
+---
+title: US ZIP Code Sample Data
+homepage: https://github.com/expressloop/us-zip-sample-data
+category: GIS
+description: >
+  Sample CSVs of US postal geography data: ZIP-level records (city and alias
+  names, county, FIPS codes, coordinates, time zone), street-level ZIP+4
+  address ranges, NPA area codes, carrier-route assignments, and geocoded
+  addresses with confidence scores. Includes a field reference and Python/SQL
+  loader examples. The samples are small slices of a larger commercial catalog,
+  published for schema evaluation.
+version:
+keywords:
+  - zip-code
+  - zip+4
+  - postal-code
+  - usa
+  - area-code
+  - geocoding
+  - reference-data
+image:
+spatial: United States
+access_level: public (direct download, no signup)
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: true
+data_dictionary: https://github.com/expressloop/us-zip-sample-data/blob/main/docs/field-reference.md
+language: en
+license: CC BY 4.0
+publisher: PostalUp
+organization: PostalUp
+issued_time: 2026-09
+sources: []


### PR DESCRIPTION
Adds a GIS entry for [US ZIP Code Sample Data](https://github.com/expressloop/us-zip-sample-data): CC BY 4.0 sample CSVs of US ZIP-level records, street-level ZIP+4 address ranges, area codes, carrier routes, and geocoded addresses, with a field reference and Python/SQL loader examples.

- Direct download from the GitHub repo, no signup or payment.
- The entry links straight at the repository per the contribution guidelines.
- Note for transparency: the files are samples of a larger commercial catalog; the samples themselves are openly licensed (CC BY 4.0).