### PR TITLE
Add World Cuisine Ingredient Overlap dataset

### DIFF
--- a/core/Agriculture/World-Cuisine-Ingredient-Overlap.yml
+++ b/core/Agriculture/World-Cuisine-Ingredient-Overlap.yml
@@ -1,0 +1,22 @@
+title: World Cuisine Ingredient Overlap
+homepage: https://www.kaggle.com/datasets/alperacax/world-cuisine-ingredient-overlap-24-cuisines
+category: Agriculture
+description: Ingredient overlap between 24 world cuisines, measured over 1,884 well-known dishes described in 7 languages. Four tables - cuisines with dish counts and centroids, 946 canonical ingredients with multilingual names, a bipartite cuisine-ingredient graph, and all 248 cuisine pairs with overlap share, great-circle distance and land-border flag. Note on provenance - the dishes are real, but their ingredient lists were written by a language model and verified by a second model pass, so this measures how a model represents these cuisines rather than how people cook. CSV, CC-BY-4.0.
+version: 1.0.0
+keywords: food, cuisine, ingredients, multilingual, network analysis, LLM evaluation
+image:
+temporal: 2026
+spatial: global
+access_level: public
+copyrights: CC-BY-4.0
+accrual_periodicity: quarterly
+specification: https://huggingface.co/datasets/alperacax/world-cuisine-ingredient-overlap
+data_quality: true
+data_dictionary: https://huggingface.co/datasets/alperacax/world-cuisine-ingredient-overlap
+language: English, Turkish, German, French, Spanish, Italian, Greek
+license: CC-BY-4.0
+publisher: eatmundo
+organization: eatmundo
+issued_time: 2026-09-03
+sources:
+  - eatmundo recipe corpus (https://www.eatmundo.com)


### PR DESCRIPTION
Adds an open dataset measuring ingredient overlap between 24 world cuisines
over 1,884 dishes described in 7 languages.

Published under CC BY 4.0 on Kaggle and Hugging Face, with a runnable
notebook. The description states the provenance explicitly: the dishes are
real, but the ingredient lists were model-written and model-verified, so the
dataset describes how a language model represents these cuisines rather than
how people cook.