### PR TITLE
Add Robot Lawn Mower Specs dataset (Agriculture)

### DIFF
--- a/core/Agriculture/Robot-Lawn-Mower-Specs.yml
+++ b/core/Agriculture/Robot-Lawn-Mower-Specs.yml
@@ -1,0 +1,25 @@
+---
+title: Robot Lawn Mower Specs
+homepage: https://github.com/yumaheymans/robot-lawn-mower-specs
+category: Agriculture
+description: Open dataset of specifications for 23 robot lawn mower models across 9 brands, covering navigation type, obstacle avoidance, rated coverage, slope rating, all-wheel-drive capability, cutting specs, and dated price snapshots, each figure attached to a cited source. Available as CSV and JSON.
+version: 1.0.0
+keywords: robot lawn mower, robotic mower, lawn care, navigation, specifications, dataset
+access_level: public
+language: en
+license: CC BY 4.0
+publisher:
+  - name: BestRobotMower.co
+    web: https://bestrobotmower.co
+organization:
+  - name: BestRobotMower.co
+    web: https://bestrobotmower.co
+issued_time: 2026.09
+sources:
+  - name: Robot Lawn Mower Specs CSV
+    access_url: https://raw.githubusercontent.com/yumaheymans/robot-lawn-mower-specs/main/data/mowers.csv
+  - name: Robot Lawn Mower Specs JSON
+    access_url: https://raw.githubusercontent.com/yumaheymans/robot-lawn-mower-specs/main/data/mowers.json
+references:
+  - title: Scoring methodology
+    reference: https://github.com/yumaheymans/robot-lawn-mower-specs/blob/main/methodology.md


### PR DESCRIPTION
Adds one dataset entry under `core/Agriculture/`.

- **Dataset:** Robot Lawn Mower Specs — https://github.com/yumaheymans/robot-lawn-mower-specs
- **License:** CC BY 4.0
- **Contents:** specs for 23 robot lawn mower models across 9 brands (navigation type, obstacle avoidance, rated coverage, slope rating, all-wheel-drive, cutting specs, dated price snapshots), each figure cited to a source. CSV and JSON, directly downloadable, no login/paywall.
- **Category fit:** Agriculture (matches existing landscaping/yard entries in the folder, e.g. Yard-Material-Coverage-Data).

Ran `./tests/testing.sh` locally against the new entry before opening this (title/homepage/category present, category matches folder).
