### PR TITLE
Add AfrPowerOS under Energy

### DIFF
--- a/core/Energy/AfrPowerOS.yml
+++ b/core/Energy/AfrPowerOS.yml
@@ -1,0 +1,24 @@
+---
+title: AfrPowerOS
+homepage: https://github.com/kawacukennedy/afrpoweros
+category: Energy
+description: Open dataset tracking civilian nuclear and energy infrastructure programs across all 54 African countries, with source-cited records and confidence labels on every entry.
+version:
+keywords: Africa, nuclear, energy, power plants, electricity access
+image:
+temporal:
+spatial: Africa
+access_level: public
+copyrights:
+accrual_periodicity:
+specification:
+data_quality: true
+data_dictionary:
+language: en
+license: MIT (code), CC BY 4.0 (data)
+publisher:
+  - name: Kennedy Kawacu
+    web: https://kawacukennedy.github.io/afrpoweros/
+organization:
+  - name: AfrPowerOS
+    web: https://kawacukennedy.github.io/afrpoweros/


### PR DESCRIPTION
## New data entry

Adds [AfrPowerOS](https://github.com/kawacukennedy/afrpoweros) under `core/Energy`.

**AfrPowerOS** is an open dataset tracking civilian nuclear and energy infrastructure programs across all 54 African countries: IAEA Milestone phases, regulators, timelines, vendors, agreements, installed capacity, generation mix, and electricity access. Every record is source-cited and carries a confidence label (Verified / Inference / Unverified).

- `homepage`: https://github.com/kawacukennedy/afrpoweros
- License: MIT (code), CC BY 4.0 (data)
- Format: validated JSON dataset (`data/afrpoweros.json`) + generated per-country static pages
- Downloadable directly (no login/barrier), actively maintained, CI-validated

## Checklist
- [x] Uses `PULL_REQUEST_TEMPLATE.yml` fields
- [x] Required fields (`title`, `homepage`, `category`) present; `category: Energy` matches folder
- [x] Points at the repository (per CONTRIBUTING #2), not a downstream consumer

Disclosure: I am the project's maintainer.