### PR TITLE
Government: add two Japanese administrative-enforcement registers

### DIFF
--- a/core/Government/Japan-JFTC-Orders-and-Recommendations.yml
+++ b/core/Government/Japan-JFTC-Orders-and-Recommendations.yml
@@ -1,0 +1,43 @@
+---
+title: Japan - JFTC Cease-and-Desist Orders and Subcontract Act Recommendations
+homepage: https://github.com/eoylab/jftc-actions
+category: Government
+description: >-
+  Machine-readable register of measures published by the Japan Fair Trade
+  Commission: 排除措置命令 (cease-and-desist orders) under the Antimonopoly Act and
+  勧告 (recommendations) under the Subcontract Act (取適法, formerly 下請法). 361
+  actions from 2010 to 2026, each with a source URL. Structured deterministically
+  from the commission's published annual index tables; the descriptive text of
+  each case is not reproduced, only the factual fields, and the dataset contains
+  no judgement of its own. Surcharge amounts are deliberately absent and recorded
+  as null, because the published index tables carry no amount column and for some
+  years the figures exist only inside images - reading them by OCR and presenting
+  the result as fact was rejected. Names of natural persons are removed from the
+  structured fields, and 15 unparsed announcements are kept separately rather than
+  guessed at. Downloadable as JSON, JSONL and CSV with no account or key.
+version: v1
+keywords:
+  - japan
+  - law
+  - regulatory-compliance
+  - antitrust
+  - competition-law
+  - enforcement
+  - administrative-law
+image:
+temporal: 2010/2026
+spatial: Japan
+access_level: public
+copyrights: Public Data License 1.0 (data); MIT (code)
+accrual_periodicity: monthly
+specification:
+data_quality: true
+data_dictionary: https://github.com/eoylab/jftc-actions/blob/main/README.md
+language: ja
+license: other-pd
+publisher: eoylab
+organization: eoylab
+issued_time: 2026-09-07
+sources:
+  - https://www.jftc.go.jp/houdou/index.html
+  - https://github.com/eoylab/jftc-actions

--- a/core/Government/Japan-Keihyoho-Enforcement-Orders.yml
+++ b/core/Government/Japan-Keihyoho-Enforcement-Orders.yml
@@ -1,0 +1,43 @@
+---
+title: Japan - Keihyoho (Premiums and Representations Act) Enforcement Orders
+homepage: https://github.com/eoylab/keihyo-cases
+category: Government
+description: >-
+  Machine-readable register of enforcement orders issued by Japan's Consumer
+  Affairs Agency under the Act against Unjustifiable Premiums and Misleading
+  Representations (景品表示法) - 措置命令 (cease-and-desist orders) and 課徴金納付命令
+  (surcharge payment orders). 151 cases published 2020-2026, plus the specific
+  provisions cited in each order. Structured deterministically from the agency's
+  own index and case pages, with a source URL on every record so any field can be
+  traced back to the page it came from. Contains no judgement of its own: each
+  record restates an order already issued and published, and nothing is inferred,
+  scored or predicted. Names of natural persons are removed from the structured
+  fields. 18 announcements that could not be parsed are kept in a separate file
+  rather than filled in by guesswork. Downloadable as JSON, JSONL and CSV with no
+  account or key.
+version: v1
+keywords:
+  - japan
+  - law
+  - regulatory-compliance
+  - advertising
+  - consumer-protection
+  - enforcement
+  - administrative-law
+image:
+temporal: 2020/2026
+spatial: Japan
+access_level: public
+copyrights: Public Data License 1.0 (data); MIT (code)
+accrual_periodicity: monthly
+specification:
+data_quality: true
+data_dictionary: https://github.com/eoylab/keihyo-cases/blob/main/README.md
+language: ja
+license: other-pd
+publisher: eoylab
+organization: eoylab
+issued_time: 2026-09-02
+sources:
+  - https://www.caa.go.jp/policies/policy/representation/fair_labeling/
+  - https://github.com/eoylab/keihyo-cases


### PR DESCRIPTION
Two entries under `core/Government/`, both Japanese administrative enforcement — the orders the agencies themselves issue, which is a different thing from legislation or court judgments and is not currently represented.

| File | Contents |
|---|---|
| `Japan-Keihyoho-Enforcement-Orders.yml` | Consumer Affairs Agency orders under the Act against Unjustifiable Premiums and Misleading Representations (景品表示法): 151 cases, 2020–2026, 措置命令 and 課徴金納付命令 with the provisions cited in each |
| `Japan-JFTC-Orders-and-Recommendations.yml` | Japan Fair Trade Commission cease-and-desist orders (Antimonopoly Act) and Subcontract Act recommendations: 361 actions, 2010–2026 |

Against the quality criteria:

- **Downloadable directly** — JSON, JSONL and CSV in the repository. No login, no purchase, no key, no rate limit.
- **Points at the repository**, per rule 2, not at a page that uses the data.
- **Uncommon to obtain legally in the open** — the agencies publish these as HTML index tables and per-case pages, one year at a time; nobody publishes them structured, and nothing aggregates the two agencies into one schema.
- **Licensing is clean** — source data is Japanese government material under the Public Data License 1.0, which permits redistribution with attribution; the code is MIT. Each repo carries the statement the licence requires, that the dataset is not created or published by the agency.

The descriptions also say what the data is *not*, because that seemed more useful than what it is:

- **no judgement of their own** — each record restates an order already issued and published; nothing is inferred, scored or predicted
- **no natural-person names** in the structured fields
- unparsed announcements (18 and 15 respectively) are kept in a separate file rather than filled in by guesswork
- the JFTC surcharge amounts are deliberately `null`, and the entry says why: the published index tables carry no amount column, and for some years the figures exist only inside images — reading them by OCR and presenting the result as fact was rejected

`python tests/validate.py` passes locally.