### PR TITLE
Add attribution to Robot Lawn Mower Specs publisher links

### DIFF
--- a/core/Agriculture/Robot-Lawn-Mower-Specs.yml
+++ b/core/Agriculture/Robot-Lawn-Mower-Specs.yml
@@ -10,10 +10,10 @@ language: en
 license: CC BY 4.0
 publisher:
   - name: BestRobotMower.co
-    web: https://bestrobotmower.co
+    web: https://bestrobotmower.co/?utm_source=awesome-public-datasets&utm_medium=listing&utm_campaign=mower-dataset
 organization:
   - name: BestRobotMower.co
-    web: https://bestrobotmower.co
+    web: https://bestrobotmower.co/?utm_source=awesome-public-datasets&utm_medium=listing&utm_campaign=mower-dataset
 issued_time: 2026.09
 sources:
   - name: Robot Lawn Mower Specs CSV


### PR DESCRIPTION
Adds UTM attribution to the two publisher website references in the accepted Robot Lawn Mower Specs entry, so visits from the metadata page can be measured. The dataset homepage points directly to its repository, and the CSV and JSON URLs are direct downloads.

Validation: ran the repository's tests/validate.py against the changed Agriculture entry and confirmed the tagged publisher destination returns HTTP 200.

Follow-up to #642.