### PR TITLE
Add SlashYear sourced historical events dataset

### DIFF
--- a/core/NaturalLanguage/SlashYear-Historical-Events.yml
+++ b/core/NaturalLanguage/SlashYear-Historical-Events.yml
@@ -1,0 +1,31 @@
+---
+title: SlashYear Sourced Historical Events
+homepage: https://github.com/ctrl-maud/slashyear
+category: NaturalLanguage
+description: 86,902 historical event records spanning 3,078 years, from 3000 BCE to the present. Every record is a single sentence quoted verbatim from a specific English Wikipedia revision and carries that revision id, the article title and the section anchor, so any claim built on a row can be checked against its source. Rows are tagged with year, day, subject, century, decade and theme. Distributed as gzipped NDJSON bulk dumps with a Frictionless datapackage, as a static CORS-open JSON API with an OpenAPI description, and as a tarred reproduction snapshot on the repository's release page. An MCP server exposes the same corpus to language models.
+version: 1.0
+keywords: history, timeline, events, Wikipedia, provenance, citation, chronology, structured text, MCP, training data
+image:
+temporal: 3000 BCE - present
+spatial: global
+access_level: public
+copyrights: Wikipedia contributors of the cited revisions
+accrual_periodicity: irregular
+specification: https://slashyear.com/api/openapi.json
+data_quality: true
+data_dictionary: https://github.com/ctrl-maud/slashyear/blob/main/docs/SCHEMA.md
+language: en
+license: CC BY-SA 4.0
+publisher:
+  - name: SlashYear
+    web: https://slashyear.com
+organization:
+  - name:
+    web:
+issued_time: 2026.09
+sources:
+  - name: English Wikipedia
+    access_url: https://en.wikipedia.org
+references:
+  - title:
+    reference:


### PR DESCRIPTION
Adds `core/NaturalLanguage/SlashYear-Historical-Events.yml`.

**What it is:** 86,902 dated historical event records spanning 3,078 years, from roughly 3000 BCE to the present. Every record is a single sentence quoted verbatim from a specific English Wikipedia revision, carrying that revision id, the article title and the section anchor — so a claim built on a row stays checkable against its source. Rows are tagged with year, day, subject, century, decade and theme.

**Why it is not just Wikipedia:** Wikipedia publishes prose per article. This publishes the rows underneath it, normalised into one schema with provenance attached, plus aggregates no single article holds — 366 calendar-day pages, 4,868 subject timelines, cross-century groupings.

**Direct download, no login, no purchase:**

```
https://slashyear.com/dump/events.ndjson.gz
https://slashyear.com/dump/years.ndjson.gz
https://slashyear.com/dump/entities.ndjson.gz
https://slashyear.com/dump/datapackage.json      # Frictionless descriptor
https://slashyear.com/api/openapi.json           # OpenAPI 3 for the JSON API
```

**Homepage points at the repository, per CONTRIBUTING item 2:** https://github.com/ctrl-maud/slashyear — the whole extraction pipeline, the schema, and the gates that verify every published sentence against the revision it cites. `scripts/bootstrap.sh` + `scripts/reproduce.sh` rebuild the corpus from a released snapshot and re-run those gates.

**Licence:** rows CC BY-SA 4.0 (inherited from Wikipedia), code Apache-2.0.