### PR TITLE
Add USDA-derived Honey Price Index dataset

### DIFF
--- a/core/Economics/HONEY_PRICE_INDEX.yml
+++ b/core/Economics/HONEY_PRICE_INDEX.yml
@@ -1,0 +1,36 @@
+---
+title: Honey Price Index (USDA-derived US honey prices)
+homepage: https://rawhoneyguide.com/price-data/honey-price-index.csv
+category: Economics
+description: >-
+  Downloadable CSV of US honey prices derived from USDA AMS National Honey
+  Reports and USDA NASS annual Honey reports. The 2026-09-09 release contains
+  3,046 observations, including 24 recorded monthly periods from July 2023
+  through July 2026 and annual producer benchmarks from 1998 through 2025.
+  Fields include reported price ranges and derived midpoints in US dollars
+  per pound, states, color grades, producer channels, imports, report dates,
+  source URLs and SHA-256 checksums. Missing months remain gaps. Domestic
+  bulk, producer and import price bases are separately labeled and are not
+  interchangeable. The CSV contains USDA-derived observations only; it does
+  not include the site's curated honey catalog or retail-price models.
+version: '2026-09-09'
+keywords: honey, USDA, agricultural prices, commodity prices, producer prices, CSV
+spatial: United States
+access_level: public
+specification: https://rawhoneyguide.com/tools/honey-price-compare/methodology
+language: en
+license: Creative Commons Attribution 4.0 International
+publisher:
+  - name: Raw Honey Guide
+    web: https://rawhoneyguide.com
+issued_time: '2026-09-09'
+sources:
+  - name: USDA-derived honey price observations CSV
+    access_url: https://rawhoneyguide.com/price-data/honey-price-index.csv
+references:
+  - title: Honey Price Index methodology, source attribution and limitations
+    reference: https://rawhoneyguide.com/tools/honey-price-compare/methodology
+  - title: USDA AMS National Honey Report
+    reference: https://www.ams.usda.gov/mnreports/fvmhoney.pdf
+  - title: USDA NASS Honey annual report issued March 2026
+    reference: https://esmis.nal.usda.gov/sites/default/release-files/795818/hony0326.pdf


### PR DESCRIPTION
Adds one Economics entry for a directly downloadable [US honey price CSV](https://rawhoneyguide.com/price-data/honey-price-index.csv) derived from USDA AMS and NASS reports. I maintain Raw Honey Guide.

The September 9, 2026 release has 3,046 observations: 24 recorded monthly periods from July 2023 through July 2026 and annual producer benchmarks for 1998–2025. Rows retain price units, report dates, source URLs and SHA-256 checksums. Missing months remain gaps; domestic bulk, producer and import price bases are labeled separately.

The [methodology](https://rawhoneyguide.com/tools/honey-price-compare/methodology) documents sources, calculations and limitations. The CSV contains USDA-derived observations only and requires no login or payment. The site's curated catalog and retail-price models are outside this listing.

Validation: `bash tests/testing.sh` passes against upstream `e7dd2d19ecc0da1483517cfc31a4642d071dda68` plus this YAML.

The direct CSV download and methodology were also verified in desktop and mobile Firefox.
