### PR TITLE
Add SCHD payment and holdings snapshots to Finance

### DIFF
--- a/core/Finance/Dividend-Data-Toolkit.yml
+++ b/core/Finance/Dividend-Data-Toolkit.yml
@@ -1,0 +1,17 @@
+---
+title: Dividend Data Toolkit - SCHD Payments and Holdings
+homepage: https://github.com/holaclea/dividend-data-toolkit
+category: Finance
+description: Dated SCHD payment and holdings snapshots with source URLs, data dictionaries, and Python tools for checking ex-dividend windows, share-split bases, and a company's indirect exposure across ETF positions. Includes 40 as-listed payment records from September 2016 to June 2026 and 102 entries from the September 8, 2026 holdings disclosure. Example investment amounts are explicitly hypothetical; this is not a live feed or complete history.
+keywords: SCHD, dividends, ETF, holdings, corporate actions, financial data
+access_level: public
+language: en
+publisher:
+  - name: DividendSteps
+    web: https://dividendsteps.com/
+sources:
+  - name: Schwab Asset Management
+    access_url: https://www.schwabassetmanagement.com/products/schd
+references:
+  - title: Data provenance and reuse boundaries
+    reference: https://github.com/holaclea/dividend-data-toolkit/blob/main/DATA-NOTICE.md


### PR DESCRIPTION
Adds a directly downloadable, dated SCHD dataset with 40 as-listed payment records (September 2016 through June 2026) and 102 entries from the September 8, 2026 holdings disclosure.

The repository separates ex-dividend dates from payable dates, preserves source URLs and snapshot dates, and includes a data dictionary, split-basis checks, and Python tools for reproducing dividend totals and indirect company exposure across ETF positions. It is a static snapshot, not a live feed or complete fund history.

Affiliation: I maintain DividendSteps and this toolkit. The entry links directly to the repository, without affiliate parameters. Original code and documentation are MIT licensed; DATA-NOTICE.md explicitly separates those rights from third-party source data.

Validation:
- Ran this repository's tests/validate.py on the added Finance entry: passed.
- - The toolkit's eight calculation and input-validation tests passed.
- - Verified all 15 published files against the tested local copies using unauthenticated public downloads.
- - Checked existing Finance entries and open/closed pull requests for this project; no duplicate was found.
Only core/Finance/Dividend-Data-Toolkit.yml is added.