### PR TITLE
Add source-linked beauty-brand purchase policy dataset

### DIFF
--- a/core/Economics/Beauty-Brand-Purchase-Policies.yml
+++ b/core/Economics/Beauty-Brand-Purchase-Policies.yml
@@ -1,0 +1,15 @@
+---
+title: Beauty Brand Purchase Policies
+homepage: https://github.com/hoannguyen10101981-spec/beauty-brand-policy-data
+category: Economics
+description: >-
+  A dated CSV and JSON reference of US-facing beauty-brand purchase policies,
+  with 60 policy summaries and 8 separately labeled official-source conflicts
+  across 12 brands. Each record includes official source URLs and a review date.
+  Topics include shipping, returns, discount eligibility and restrictions.
+  AI-assisted curation; a convenience sample, not a representative survey or live coupon feed.
+access_level: public
+language: en
+license: CC BY 4.0 (curated data and documentation); MIT (query utility)
+keywords: consumer policies, retail, shipping, returns, beauty brands
+temporal: 2026-09-11 snapshot

--- a/core/Economics/Beauty-Brand-Purchase-Policies.yml
+++ b/core/Economics/Beauty-Brand-Purchase-Policies.yml
@@ -1,15 +1,15 @@
 ---
-title: Beauty Brand Purchase Policies
-homepage: https://github.com/hoannguyen10101981-spec/beauty-brand-policy-data
+title: Beauty Brand Returns and Shipping Policies
+homepage: https://github.com/hoannguyen10101981-spec/beautypolicies
 category: Economics
 description: >-
-  A dated CSV and JSON reference of US-facing beauty-brand purchase policies,
-  with 60 policy summaries and 8 separately labeled official-source conflicts
-  across 12 brands. Each record includes official source URLs and a review date.
-  Topics include shipping, returns, discount eligibility and restrictions.
-  AI-assisted curation; a convenience sample, not a representative survey or live coupon feed.
+  A dated CSV and JSON comparison of return windows, return postage,
+  free-shipping conditions and opened-product rules across 48 beauty brands
+  and retailers serving US shoppers. Records retain official source URLs,
+  review dates and explicit Unconfirmed values. AI-assisted export of
+  published policy summaries; not a representative survey or live offer feed.
 access_level: public
 language: en
-license: CC BY 4.0 (curated data and documentation); MIT (query utility)
+license: CC BY 4.0 (compilation and authored summaries)
 keywords: consumer policies, retail, shipping, returns, beauty brands
-temporal: 2026-09-11 snapshot
+temporal: 2026-09-12 policy snapshot


### PR DESCRIPTION
Adds a dated consumer-policy dataset under Economics: https://github.com/hoannguyen10101981-spec/beautypolicies

The CSV and JSON contain 48 beauty-brand and retailer records, covering return windows, return postage, free-shipping conditions and opened-product rules. Each record retains official source URLs and its 2026-09-12 review date; missing facts remain explicitly Unconfirmed. The README documents every field and the manual snapshot update method. Compilation and authored summaries are CC BY 4.0.

This is an AI-assisted export of already published policy summaries, not a representative survey or live offer feed. I am submitting on behalf of the dataset owner. The existing entry and pull request are updated in place to avoid duplicate submissions.

Validation: CSV and JSON round-trip to identical 48-record, seven-field data; public raw files match the local export byte for byte. The entry category matches its Economics directory.