### PR TITLE
Add two open API/software pricing datasets (Software category)

### DIFF
--- a/core/Software/pricing-models-API-pricing-dataset.yml
+++ b/core/Software/pricing-models-API-pricing-dataset.yml
@@ -1,0 +1,31 @@
+---
+title: pricing-models — per-unit API pricing dataset
+homepage: https://github.com/UNAUTH-ACCESS/pricing-models
+category: Software
+description: Machine-readable per-unit pricing for the APIs developers build on — LLM inference, speech, messaging, maps, and vector databases. One JSON file per provider, each carrying a verified_at date and a pricing_url to the source page. LLM rates are cross-checked against OpenRouter's live models API; other categories are read by hand against the vendor's own pricing page. A merged build (all providers, and one file per category) is generated and published alongside the per-provider source files. Powers api-rate.store, a pricing-comparison site for cloud/API services. Open for corrections via issue or PR.
+version: 1.0
+keywords: api pricing, llm pricing, cloud pricing, developer tools, json, open data
+image:
+temporal:
+spatial: global
+access_level: public
+copyrights:
+accrual_periodicity: irregular
+specification: https://github.com/UNAUTH-ACCESS/pricing-models#provider-file
+data_quality: true
+data_dictionary: https://github.com/UNAUTH-ACCESS/pricing-models/blob/main/schema.json
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: api-rate.store
+    web: https://api-rate.store
+organization:
+issued_time: 2026.09
+sources:
+  - name: Per-provider source files
+    access_url: https://github.com/UNAUTH-ACCESS/pricing-models/tree/main/providers
+  - name: Merged build, all providers (JSON)
+    access_url: https://raw.githubusercontent.com/UNAUTH-ACCESS/pricing-models/main/build/all.json
+references:
+  - title: Schema and field reference
+    reference: https://github.com/UNAUTH-ACCESS/pricing-models#provider-file

--- a/core/Software/software-pricing-dataset.yml
+++ b/core/Software/software-pricing-dataset.yml
@@ -1,0 +1,33 @@
+---
+title: Software & AI-tool pricing comparison dataset
+homepage: https://github.com/UNAUTH-ACCESS/software-pricing-dataset
+category: Software
+description: An open, dated index of software and AI-tool pricing comparisons. Each entry names the vendors compared, links their official pricing pages, and records the date the figures were last verified against those pages. Covers AI assistants & models, developer tools, security, productivity, marketing, and business-ops software; 162 entries as of September 2026 and growing. Maintained alongside StackLegder, where each row is a full written comparison with pricing tables and sources. Published as JSON and a flattened CSV; corrections are tracked and fixed at the source.
+version: 1.0
+keywords: software pricing, saas pricing, ai tools, comparison, csv, json, open data
+image:
+temporal: 2026-09 snapshot, updated ongoing
+spatial: global
+access_level: public
+copyrights:
+accrual_periodicity: daily
+specification: https://github.com/UNAUTH-ACCESS/software-pricing-dataset#schema
+data_quality: true
+data_dictionary: https://github.com/UNAUTH-ACCESS/software-pricing-dataset#schema
+language: en
+license: CC-BY-4.0
+publisher:
+  - name: StackLegder
+    web: https://stacklegder.online
+organization:
+issued_time: 2026.09
+sources:
+  - name: Full dataset (JSON)
+    access_url: https://raw.githubusercontent.com/UNAUTH-ACCESS/software-pricing-dataset/main/data/pricing.json
+  - name: Full dataset, flattened (CSV)
+    access_url: https://raw.githubusercontent.com/UNAUTH-ACCESS/software-pricing-dataset/main/data/pricing.csv
+  - name: Live source, always current
+    access_url: https://stacklegder.online/data/pricing.json
+references:
+  - title: Schema and field reference
+    reference: https://github.com/UNAUTH-ACCESS/software-pricing-dataset#schema


### PR DESCRIPTION
Two entries, both CC BY 4.0, both actively maintained:

- **pricing-models** — per-unit API pricing (LLM inference, speech, messaging, maps, vector DBs), one JSON file per provider, each with a `verified_at` date and source URL. LLM rates cross-checked against OpenRouter's live models API.
- **software-pricing-dataset** — dated index of software/AI-tool pricing comparisons, 162 entries, JSON + CSV, each entry linking the vendor pricing pages it was verified against.

Ran `tests/validate.py`'s required-field checks against both new entries locally — `title`/`homepage`/`category` all present and `category` matches the folder (`Software`).

Disclosure: I maintain both datasets (they back stacklegder.online and api-rate.store), so this is a self-submission — happy to adjust format/category or split into separate PRs if that's preferred.